### PR TITLE
fix(react-dom): fire onChange on every keystroke for text inputs

### DIFF
--- a/packages/react-dom/src/dom.ts
+++ b/packages/react-dom/src/dom.ts
@@ -243,33 +243,66 @@ function setEventHandler(el: Element, name: string, next: any, prev: any): void 
   if (next != null && typeof next !== 'function') next = null
 
   const capture = name.endsWith('Capture')
-  const eventName = normalizeEventName(name.slice(2, capture ? -7 : undefined))
+  const reactEventName = name.slice(2, capture ? -7 : undefined)
+  const eventName = domEventFor(reactEventName, el)
 
+  // Key by the React prop name (not DOM event name) so `onChange` and
+  // `onInput` on the same text input — which both dispatch from the native
+  // `input` event — can coexist without clobbering each other's handlers.
   const handlers = ((el as any).__handlers ||= Object.create(null))
-  const key = eventName + (capture ? '_c' : '_b')
+  const key = name
 
-  if (handlers[key] && !next) {
-    el.removeEventListener(eventName, handlers[key].listener, capture)
+  const existing = handlers[key]
+
+  if (existing && !next) {
+    el.removeEventListener(existing.event, existing.listener, existing.capture)
     handlers[key] = null
     return
   }
 
-  if (!handlers[key] && next) {
-    const entry = { current: next as Function, listener: null as any }
+  if (!existing && next) {
+    const entry = {
+      current: next as Function,
+      listener: null as any,
+      event: eventName,
+      capture,
+    }
     entry.listener = (e: Event) => entry.current(e)
     handlers[key] = entry
     el.addEventListener(eventName, entry.listener, capture)
     return
   }
 
-  if (handlers[key]) {
-    handlers[key].current = next
+  if (existing) {
+    // Re-bind if the effective DOM event changed (e.g. <input> whose `type`
+    // flipped from "text" to "checkbox" — onChange should now follow `change`
+    // instead of `input`). This is rare but keeps semantics correct.
+    if (existing.event !== eventName || existing.capture !== capture) {
+      el.removeEventListener(existing.event, existing.listener, existing.capture)
+      existing.event = eventName
+      existing.capture = capture
+      el.addEventListener(eventName, existing.listener, capture)
+    }
+    existing.current = next
   }
 }
 
-function normalizeEventName(name: string): string {
-  const lower = name.toLowerCase()
-  // React naming quirks → DOM
+function domEventFor(reactEventName: string, el: Element): string {
+  const lower = reactEventName.toLowerCase()
+  // React's `onChange` on text-like <input> and <textarea> maps to the
+  // native `input` event so handlers fire on every keystroke. On checkbox,
+  // radio, file inputs, and <select>, React's `onChange` maps to the
+  // native `change` event (which fires on click / option select).
+  if (lower === 'change') {
+    const tag = el.tagName
+    if (tag === 'TEXTAREA') return 'input'
+    if (tag === 'INPUT') {
+      const type = ((el as HTMLInputElement).type || 'text').toLowerCase()
+      if (type !== 'checkbox' && type !== 'radio' && type !== 'file') {
+        return 'input'
+      }
+    }
+  }
   if (lower === 'doubleclick') return 'dblclick'
   return lower
 }

--- a/packages/react-dom/src/reconcile.ts
+++ b/packages/react-dom/src/reconcile.ts
@@ -635,8 +635,18 @@ function renderHost(fiber: Fiber, domParent: Node, anchor: Node | null): void {
     const hydrated = currentRoot?.hydrating ? adoptHostDom(fiber, fiber.parent!) : false
     if (!hydrated) {
       fiber.dom = createHostNode(type, isSvg)
+      // Two passes so form-control attributes (notably <input type>) are in
+      // place before event handlers attach. setEventHandler reads the
+      // element's runtime state to decide the DOM event name (e.g. onChange
+      // → `input` vs `change`); binding before `type` is applied would
+      // attach to the wrong event for checkbox/radio/file inputs.
       for (const k in props) {
         if (isSelect && (k === 'value' || k === 'defaultValue')) continue
+        if (isEventProp(k)) continue
+        setProp(fiber.dom as Element, k, props[k], undefined, isSvg)
+      }
+      for (const k in props) {
+        if (!isEventProp(k)) continue
         setProp(fiber.dom as Element, k, props[k], undefined, isSvg)
       }
       insertInto(domParent, fiber.dom, anchor)
@@ -647,8 +657,16 @@ function renderHost(fiber: Fiber, domParent: Node, anchor: Node | null): void {
     for (const k in prev) {
       if (!(k in props)) setProp(el, k, undefined, prev[k], isSvg)
     }
+    // Non-event props first for the same reason as above: a `type` change
+    // must land before we ask setEventHandler to resolve the DOM event for
+    // `onChange`.
     for (const k in props) {
       if (isSelect && (k === 'value' || k === 'defaultValue')) continue
+      if (isEventProp(k)) continue
+      if (prev[k] !== props[k]) setProp(el, k, props[k], prev[k], isSvg)
+    }
+    for (const k in props) {
+      if (!isEventProp(k)) continue
       if (prev[k] !== props[k]) setProp(el, k, props[k], prev[k], isSvg)
     }
     if (prev !== props) syncRefIfChanged(fiber, fiber.dom)
@@ -1518,6 +1536,15 @@ function runEffect(fiber: Fiber, effect: Effect, root: FiberRoot): void {
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
+
+function isEventProp(name: string): boolean {
+  return (
+    name.length > 2 &&
+    name.charCodeAt(0) === 111 /* o */ &&
+    name.charCodeAt(1) === 110 /* n */ &&
+    name.charCodeAt(2) >= 65 /* 'A'-ish: any uppercase start (onClick, onChange, …) */
+  )
+}
 
 function shallowEqual(a: any, b: any): boolean {
   if (a === b) return true

--- a/tests/controlled-input.test.tsx
+++ b/tests/controlled-input.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Controlled-input behavior — parity with React.
+ *
+ * React's `onChange` on text-like <input>/<textarea> fires on every
+ * keystroke (i.e. is wired to the native `input` event, not `change`).
+ * The native `change` event only fires on blur/enter, which makes
+ * controlled inputs in DocSearch-style search modals appear dead: the
+ * user types, nothing re-renders, no results show up.
+ *
+ * These tests lock that contract down so we don't regress it again.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+function dispatchInput(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  el.value = value
+  el.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
+}
+
+describe('controlled inputs — onChange semantics', () => {
+  it('onChange on text input fires on each keystroke (native input event)', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    function App() {
+      const [v, setV] = React.useState('')
+      return (
+        <input
+          id="search"
+          value={v}
+          onChange={(e) => {
+            changes.push((e.target as HTMLInputElement).value)
+            setV((e.target as HTMLInputElement).value)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#search') as HTMLInputElement
+
+    flushSync(() => dispatchInput(input, 'h'))
+    flushSync(() => dispatchInput(input, 'he'))
+    flushSync(() => dispatchInput(input, 'hel'))
+
+    expect(changes).toEqual(['h', 'he', 'hel'])
+    expect(input.value).toBe('hel')
+  })
+
+  it('onChange on textarea fires on each keystroke', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    function App() {
+      const [v, setV] = React.useState('')
+      return (
+        <textarea
+          id="ta"
+          value={v}
+          onChange={(e) => {
+            changes.push((e.target as HTMLTextAreaElement).value)
+            setV((e.target as HTMLTextAreaElement).value)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const ta = container.querySelector('#ta') as HTMLTextAreaElement
+
+    flushSync(() => dispatchInput(ta, 'a'))
+    flushSync(() => dispatchInput(ta, 'ab'))
+
+    expect(changes).toEqual(['a', 'ab'])
+  })
+
+  it('onInput on text input still fires on input event', () => {
+    const container = setup()
+    const inputs: Array<string> = []
+    function App() {
+      return (
+        <input
+          id="search"
+          defaultValue=""
+          onInput={(e) => {
+            inputs.push((e.target as HTMLInputElement).value)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#search') as HTMLInputElement
+
+    dispatchInput(input, 'x')
+    dispatchInput(input, 'xy')
+
+    expect(inputs).toEqual(['x', 'xy'])
+  })
+
+  it('onChange AND onInput can coexist on the same text input', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    const inputs: Array<string> = []
+    function App() {
+      return (
+        <input
+          id="both"
+          defaultValue=""
+          onChange={(e) => changes.push((e.target as HTMLInputElement).value)}
+          onInput={(e) => inputs.push((e.target as HTMLInputElement).value)}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#both') as HTMLInputElement
+
+    dispatchInput(input, 'z')
+
+    expect(changes).toEqual(['z'])
+    expect(inputs).toEqual(['z'])
+  })
+
+  it('onChange on checkbox fires on native change event (click)', () => {
+    const container = setup()
+    let fires = 0
+    function App() {
+      const [checked, setChecked] = React.useState(false)
+      return (
+        <input
+          id="cb"
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => {
+            fires++
+            setChecked((e.target as HTMLInputElement).checked)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const cb = container.querySelector('#cb') as HTMLInputElement
+
+    flushSync(() => cb.click())
+    expect(fires).toBe(1)
+    expect(cb.checked).toBe(true)
+  })
+
+  it('onChange on radio fires on native change event (click)', () => {
+    const container = setup()
+    let fires = 0
+    function App() {
+      const [v, setV] = React.useState('a')
+      return (
+        <>
+          <input
+            id="ra"
+            type="radio"
+            name="g"
+            checked={v === 'a'}
+            onChange={() => {
+              fires++
+              setV('a')
+            }}
+          />
+          <input
+            id="rb"
+            type="radio"
+            name="g"
+            checked={v === 'b'}
+            onChange={() => {
+              fires++
+              setV('b')
+            }}
+          />
+        </>
+      )
+    }
+    createRoot(container).render(<App />)
+    const rb = container.querySelector('#rb') as HTMLInputElement
+    flushSync(() => rb.click())
+    expect(fires).toBe(1)
+    expect(rb.checked).toBe(true)
+  })
+
+  it('onChange on select fires on native change event', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    function App() {
+      const [v, setV] = React.useState('a')
+      return (
+        <select
+          id="s"
+          value={v}
+          onChange={(e) => {
+            const next = (e.target as HTMLSelectElement).value
+            changes.push(next)
+            setV(next)
+          }}
+        >
+          <option value="a">a</option>
+          <option value="b">b</option>
+          <option value="c">c</option>
+        </select>
+      )
+    }
+    createRoot(container).render(<App />)
+    const sel = container.querySelector('#s') as HTMLSelectElement
+
+    sel.value = 'b'
+    flushSync(() => sel.dispatchEvent(new Event('change', { bubbles: true })))
+
+    expect(changes).toEqual(['b'])
+  })
+
+  it('controlled value is written back after user types (re-render wins)', () => {
+    const container = setup()
+    function App() {
+      const [v, setV] = React.useState('')
+      return (
+        <input
+          id="ctrl"
+          value={v.toUpperCase()}
+          onChange={(e) => setV((e.target as HTMLInputElement).value)}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#ctrl') as HTMLInputElement
+
+    flushSync(() => dispatchInput(input, 'foo'))
+    expect(input.value).toBe('FOO')
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes broken search/documentation modals on tanstack.com: controlled `<input>` / `<textarea>` looked dead under the shim because `onChange` was wired to the native `change` event (fires only on blur) instead of `input` (fires on each keystroke), which is React's actual semantics.
- `dom.ts`: `domEventFor()` maps `onChange` → native `input` for text-like `<input>` and `<textarea>`; keeps `change` for checkbox/radio/file/`<select>`. Handlers are keyed by React prop name so `onChange` + `onInput` can coexist; re-binds automatically if an input's `type` changes after mount.
- `reconcile.ts`: two-pass prop application in `renderHost` — non-event props before event handlers — so `<input type>` is in place before `setEventHandler` reads it.
- `tests/controlled-input.test.tsx`: dispatches real `input` / `change` events and asserts handler invocation + controlled-value writeback. The existing form-control tests (ports of React's SSR integration suite) only asserted initial DOM output and never fired events — which is why this shipped broken.

## Test plan

- [x] `pnpm --filter tests test` — 681/681 passing (28 files; +8 new cases in `controlled-input.test.tsx`)
- [ ] Manual: open DocSearch modal on tanstack.com, type, confirm results populate