### PR TITLE
docs: update SURFACE.md and SAVINGS_ANALYSIS.md for @tanstack/redact

### DIFF
--- a/docs/SAVINGS_ANALYSIS.md
+++ b/docs/SAVINGS_ANALYSIS.md
@@ -1,25 +1,27 @@
 # Where the size savings come from
 
-Numbers from `scripts/size-react-real.mjs` (esbuild: bundle + minify + `NODE_ENV=production` + tree-shake + gzip). Both stacks measured identically.
+Numbers from `scripts/size.mjs` (esbuild: bundle + minify + `NODE_ENV=production` + tree-shake + gzip) for `@tanstack/redact@0.0.1`, and `scripts/size-react-real.mjs` for React 19.2.3 measured identically.
 
 ## Per-entry comparison vs React 19.2.3
 
-| Entry | React 19 gzip | tanstack-react gzip | Ratio | Savings |
+| Entry | React 19 gzip | `@tanstack/redact` (full) | Ratio | Savings |
 |---|---:|---:|---:|---:|
-| `react` | 3.3 KB | 2.1 KB | 64% | −1.2 KB |
-| `react/jsx-runtime` | 0.7 KB | 0.2 KB | 29% | −0.5 KB |
-| `react-dom` | 4.4 KB | 6.8 KB | 154% | +2.4 KB\* |
-| `react-dom/client` | **60.3 KB** | **7.1 KB** | **12%** | **−53.2 KB** |
-| `react-dom/server` | 61.1 KB | 4.0 KB | 7% | −57.1 KB |
-| **Client total** (react + react-dom/client + jsx-runtime) | **60.5 KB** | **8.9 KB** | **15%** | **−51.6 KB** |
+| `react` | 3.29 KB | 2.65 KB | 81% | −0.64 KB |
+| `react/jsx-runtime` | 731 B | 189 B | 26% | −542 B |
+| `react-dom` | 4.35 KB | 8.53 KB | 196% | +4.18 KB\* |
+| `react-dom/client` | **60.27 KB** | **9.07 KB** | **15%** | **−51.20 KB** |
+| `react-dom/server` | 61.11 KB | 4.59 KB | 8% | −56.52 KB |
+| **Client total** (`react` + `react-dom/client` + `react/jsx-runtime`) | **60.48 KB** | **11.18 KB** | **18%** | **−49.30 KB** |
 
-\* `react-dom` (the index) looks worse because React splits it into a tiny facade over `react-dom/client`; ours is one file. Real apps ship `react-dom/client`, so that row is what matters.
+\* `react-dom` (the index) looks worse because React splits it into a tiny facade over `react-dom/client`; ours ships `createPortal`, `flushSync`, `unstable_batchedUpdates`, and resource-hint stubs in one file. Real apps ship `react-dom/client`, so that row is what matters.
+
+The `nano` preset (every opt-in feature stubbed) brings `react-dom/client` down further to **6.75 KB gzip** — a 2.32 KB savings vs `full` and a **8.9× reduction** vs React's `react-dom/client`.
 
 React 18 was ~43 KB gzip for the full client runtime; React 19 jumped to ~60 KB mostly because of `use()`, server actions (`useActionState`, `useFormStatus`), `useOptimistic`, view transitions, and async-transition plumbing.
 
-**Bottom line: a single-import client bundle shrinks from ~60 KB to ~9 KB, a 51 KB (~85%) reduction.** The win comes almost entirely from `react-dom/client` — React's `react` package is only ~3 KB to begin with.
+**Bottom line: a single-import client bundle shrinks from ~60 KB to ~11 KB, a ~49 KB (~82%) reduction at full parity, or to ~9.4 KB (~84% reduction) on the `nano` preset.** The win comes almost entirely from `react-dom/client` — React's `react` package is only ~3 KB to begin with.
 
-## Where those 51 KB go in React (approximation)
+## Where those ~49 KB go in React (approximation)
 
 Reading React's source, the 60 KB of `react-dom/client` roughly splits as:
 
@@ -41,12 +43,30 @@ Reading React's source, the 60 KB of `react-dom/client` roughly splits as:
 | Portals with full container-handoff + event retargeting | 1 KB | basic |
 | Class component lifecycles (getSnapshotBeforeUpdate, legacy context) | 1 KB | most lifecycles |
 
-Total accounted: ~52 KB, which matches the observed delta.
+Total accounted: ~52 KB, which roughly matches the observed 51 KB delta on `react-dom/client`.
+
+## Per-feature savings (full → stub)
+
+The 8 opt-in features can each be stubbed individually. Numbers from `pnpm size`, measuring `react-dom/client` with the listed feature flagged off:
+
+| Feature | full → stub savings (gzip) |
+|---|---:|
+| `portal` | ~30 B |
+| `context` | ~80 B |
+| `suspense` | **~640 B** |
+| `memo` | ~80 B |
+| `forwardRef` | ~70 B |
+| `lazy` | ~20 B |
+| `classComponents` | ~200 B |
+| `hydration` | **~1270 B** |
+| **All off (`nano` preset)** | **~2320 B** |
+
+Stubbed features still carry a small registration footprint (matcher entry that maps the React element type to Fragment, dispatcher capability defaults). The `nano` preset's total savings is slightly less than the sum of individual savings because some feature code is shared.
 
 ## What we **didn't** skip
 
 We implement in full or close to full:
-- Common hooks: `useState`, `useReducer`, `useEffect`, `useLayoutEffect`, `useRef`, `useMemo`, `useCallback`, `useContext`, `useImperativeHandle`, `useSyncExternalStore`, `use()`
+- Common hooks: `useState`, `useReducer`, `useEffect`, `useLayoutEffect`, `useRef`, `useMemo`, `useCallback`, `useContext`, `useImperativeHandle`, `useSyncExternalStore`, `useSyncExternalStoreWithSelector`, `use()`, `useEffectEvent`
 - `createElement`, `cloneElement`, `isValidElement`, `Children.*`
 - `createContext` with `Provider` / `Consumer` / `useContext`
 - `memo`, `forwardRef`, `lazy` with Suspense integration
@@ -72,9 +92,9 @@ Ranked by how likely they are to bite a real app:
 7. **Typing feels slightly worse under contention** — no priority boost for user input.
 8. **StrictMode is a no-op** — dev-mode detection of unsafe side effects is gone.
 
-## What this means for the 8.9 KB budget
+## What this means for the 11 KB budget
 
-Client bundle is 8.9 KB gzip total; the reconciler + dispatcher + dom + hydration alone is 7.1 KB. That 7.1 KB is what shaves 53 KB off React's 60 KB `react-dom/client` — a **~8.5× reduction**. The delta comes from skipping the four things that define React's production runtime:
+Client bundle is 11.18 KB gzip total at full parity; the reconciler + dispatcher + DOM + hydration alone is ~8.3 KB. That ~8.3 KB is what shaves 51 KB off React's 60 KB `react-dom/client` — a **6.6× reduction**. The delta comes from skipping the four things that define React's production runtime:
 
 - Fiber (double-buffered work-in-progress tree)
 - Scheduler (priority + lanes + interruption)
@@ -87,6 +107,6 @@ Re-adding any of them costs:
 - Full synthetic events: +4–6 KB
 - Dev warnings + DevTools: +3–5 KB
 
-All four together: +14–22 KB, taking us to 22–30 KB — still roughly half of React, but no longer Preact-territory.
+All four together: +14–22 KB, taking us to 25–33 KB — still roughly half of React, but no longer Preact-territory.
 
 **The size claim isn't magic.** We skipped the four expensive subsystems, kept the API shape, and accepted the UX trade-offs that come with that choice.

--- a/docs/SURFACE.md
+++ b/docs/SURFACE.md
@@ -1,7 +1,6 @@
-# React 19 API Surface — Implementation Plan
+# React 19 API Surface — `@tanstack/redact`
 
-Goal: API-complete drop-in replacement for `react` + `react-dom` targeting TanStack Start apps (tanstack.com).
-Target size: ~8-11KB gzipped client.
+API-complete drop-in replacement for `react` + `react-dom` targeting TanStack Start apps (tanstack.com). Shipped as `@tanstack/redact@0.0.1`. Client total: **11.18 KB gzip** (full preset) / **9.40 KB gzip** (nano preset, with feature flags off).
 
 ## Legend
 
@@ -197,20 +196,26 @@ React and react-dom coordinate via `ReactSharedInternals` (current dispatcher, b
 
 ## Package layout
 
+A single `@tanstack/redact` package with subpath exports. Each subpath maps to a React-shape specifier the Vite plugin (or your own bundler aliases) rewrites:
+
 ```
-packages/
-  core/                   # VDOM types + diff algorithm
-  react/                  # 'react' entrypoint
-  react-dom/              # 'react-dom' + 'react-dom/client'
-  react-dom-server/       # 'react-dom/server'
-  jsx-runtime/            # 'react/jsx-runtime' + 'react/jsx-dev-runtime'
-  scheduler/              # 'scheduler' shim
-  hydration-runtime/      # tiny inline script for boundary reveal + event replay
+packages/redact/
+  src/
+    core/                 # VDOM types + symbols (FiberTag, Hook, ReactNode, …)
+    react/                # 'react'                  → @tanstack/redact
+    dom/                  # 'react-dom'              → @tanstack/redact/dom
+                          # 'react-dom/client'       → @tanstack/redact/dom-client
+                          # 'react-dom/test-utils'   → @tanstack/redact/dom-test-utils
+      features/           # opt-in features (each is index/full/stub triple)
+        portal/  context/  suspense/  memo/
+        forward-ref/  lazy/  class/  hydration/
+    server/               # 'react-dom/server'       → @tanstack/redact/server
+    scheduler/            # 'scheduler'              → @tanstack/redact/scheduler
+    vite/                 # redact() Vite plugin     → @tanstack/redact/vite
+  package.json            # subpath exports for all of the above + ./features/* + ./_all
 ```
 
-Each exposes the exact package name React uses via `package.json` `name` field so bundler aliases map cleanly:
-- `tanstack-react` → alias plan for consumers
-- Individual subpackages use `name: "react"` etc. when installed as replacements (or we publish under a namespace and consumers configure aliases).
+Bundler aliases are wired up by the `redact()` Vite plugin (or manually for non-Vite bundlers). User code keeps its canonical `import { useState } from 'react'` — the swap happens at the bundler level, never at the source level.
 
 ---
 
@@ -224,16 +229,17 @@ Each exposes the exact package name React uses via `package.json` `name` field s
 
 ---
 
-## Size budget (working targets)
+## Size (shipped)
 
-| Package | Target gzip |
-|---|---|
-| react | 2.0 KB |
-| react-dom (client) | 5.0 KB |
-| react-dom-server | 3.0 KB (server-only, doesn't count toward client) |
-| jsx-runtime | 0.3 KB |
-| scheduler | 0.2 KB |
-| hydration-runtime | 0.8 KB (inline) |
-| **Total client** | **~8-9 KB** |
+Numbers from `pnpm size` against `@tanstack/redact@0.0.1`. The user-facing column names are the React-shape aliases the Vite plugin sets up.
 
-Server-side weight doesn't matter for the page-weight goal.
+| Subpath | min | gzip | brotli |
+|---|---:|---:|---:|
+| `react` | 6.59 KB | **2.65 KB** | 2.41 KB |
+| `react/jsx-runtime` | 247 B | 189 B | 178 B |
+| `react-dom/client` (`full`) | 26.56 KB | **9.07 KB** | 8.21 KB |
+| `react-dom/client` (`nano`) | 18.75 KB | **6.75 KB** | 6.10 KB |
+| `react-dom/server` | 11.48 KB | 4.59 KB | 4.16 KB |
+| **Client total** (`full`: react + react-dom/client + jsx-runtime) | 32.63 KB | **11.18 KB** | 10.14 KB |
+
+Server-side weight doesn't count toward the page-weight goal. Per-feature gzip deltas (for sizing individual feature flags) live in [SAVINGS_ANALYSIS.md](./SAVINGS_ANALYSIS.md).


### PR DESCRIPTION
## Summary

The two docs in `docs/` were last touched before the rename + consolidation. They still described the previous 6-package layout, used the old `tanstack-react` project name, and listed stale size numbers from before the feature-flag system landed.

- **SURFACE.md** — rewrote the Package layout section for the consolidated `packages/redact/src/{core,react,dom,server,scheduler,vite}/` tree with React-shape alias mapping. Replaced the speculative "Size budget (working targets)" with the actual shipped sizes from `pnpm size`.
- **SAVINGS_ANALYSIS.md** — refreshed every number against React 19.2.3 measured by `scripts/size-react-real.mjs` and `@tanstack/redact@0.0.1` measured by `scripts/size.mjs`. Added a new "Per-feature savings (full → stub)" table covering all 8 opt-in features.

## Test plan

- [x] `grep -E 'tanstack-react|tanstackDom|@tanstack/react[^-]|@tanstack/react-dom|@tanstack/dom-core|@tanstack/dom-vite|@tanstack/scheduler' docs/*.md` — no stale refs (only legitimate external `@tanstack/react-store`/`@tanstack/react-start-rsc` mentions remain)
- [x] Numbers cross-checked against `node scripts/size.mjs` and `node scripts/size-react-real.mjs`