### PR TITLE
fix(redact): switch exports to `default` so RSC + other conditions resolve

### DIFF
--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/redact",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "React, redacted. A minimal React-API-compatible drop-in replacement.",
   "type": "module",
   "main": "./dist/react/index.js",
@@ -9,47 +9,47 @@
   "exports": {
     ".": {
       "types": "./dist/react/index.d.ts",
-      "import": "./dist/react/index.js"
+      "default": "./dist/react/index.js"
     },
     "./jsx-runtime": {
       "types": "./dist/react/jsx-runtime.d.ts",
-      "import": "./dist/react/jsx-runtime.js"
+      "default": "./dist/react/jsx-runtime.js"
     },
     "./jsx-dev-runtime": {
       "types": "./dist/react/jsx-runtime.d.ts",
-      "import": "./dist/react/jsx-runtime.js"
+      "default": "./dist/react/jsx-runtime.js"
     },
     "./dom": {
       "types": "./dist/dom/index.d.ts",
-      "import": "./dist/dom/index.js"
+      "default": "./dist/dom/index.js"
     },
     "./dom-client": {
       "types": "./dist/dom/client.d.ts",
-      "import": "./dist/dom/client.js"
+      "default": "./dist/dom/client.js"
     },
     "./dom-test-utils": {
       "types": "./dist/dom/test-utils.d.ts",
-      "import": "./dist/dom/test-utils.js"
+      "default": "./dist/dom/test-utils.js"
     },
     "./server": {
       "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js"
+      "default": "./dist/server/index.js"
     },
     "./scheduler": {
       "types": "./dist/scheduler/index.d.ts",
-      "import": "./dist/scheduler/index.js"
+      "default": "./dist/scheduler/index.js"
     },
     "./vite": {
       "types": "./dist/vite/index.d.ts",
-      "import": "./dist/vite/index.js"
+      "default": "./dist/vite/index.js"
     },
     "./features/*": {
       "types": "./dist/dom/features/*.d.ts",
-      "import": "./dist/dom/features/*.js"
+      "default": "./dist/dom/features/*.js"
     },
     "./_all": {
       "types": "./dist/dom/_all.d.ts",
-      "import": "./dist/dom/_all.js"
+      "default": "./dist/dom/_all.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

`0.0.1` declared every subpath export under the `import` condition only:

\`\`\`json
".": { "types": "…", "import": "…" }
\`\`\`

That works for plain ESM imports but Vite's RSC environment (`@vitejs/plugin-rsc`) resolves with the condition set `["react-server", "module", "node", "development", "require"]` — no `import` in there, so the package was effectively unreachable from any RSC graph. tanstack.com migration to `@tanstack/redact` failed dep-pre-bundle with:

\`\`\`
Error: "./dom" is not exported under the conditions
["react-server", "module", "node", "development", "require"]
from package .../@tanstack/redact
\`\`\`

Switching every subpath to `default` makes the same file the fallback for any condition context — RSC, ESM, Node, anything. Files are still ESM (`"type": "module"` is unchanged); `default` just removes the gate.

Why other consumers didn't hit it:
- **tannerlinsley.com** (Cloudflare workerd) — its alias plugin resolves before condition matching kicks in.
- **vitest test suite** (707/707 passing) — uses plain ESM imports, hits `import` directly.

Version bumped to `0.0.2`.

## Test plan

- [x] tanstack.com `pnpm dev` boots cleanly with patched `0.0.2` package.json — `VITE v8.0.3 ready in 2450 ms`, `GET /` returns 200 with 196 KB rendered HTML and correct `<title>`
- [x] Existing 707/707 tests still pass (no JS source changes, only `package.json` metadata)
- [ ] Will republish as `@tanstack/redact@0.0.2` after merge