### PR TITLE
fix(redact): scope resolve.alias to client+ssr envs so RSC stays on real React

### DIFF
--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/redact",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "React, redacted. A minimal React-API-compatible drop-in replacement.",
   "type": "module",
   "main": "./dist/react/index.js",

--- a/packages/redact/src/vite/index.ts
+++ b/packages/redact/src/vite/index.ts
@@ -306,35 +306,33 @@ export function redact(options: RedactOptions = {}): any {
       const excludeList = entries.map(([k]) => k)
       // Single package — only one name to dedupe / no-external.
       const noExt = ['@tanstack/redact']
-      // Top-level resolve.alias so `react` → `@tanstack/redact` happens
-      // BEFORE any plugin-based resolveId hook fires. The Cloudflare
-      // vite-plugin's rolldown worker-runner pre-scans the worker entry's
-      // exports and resolves bare specifiers via Vite's alias map directly
-      // (not via plugin hooks), so without this it would resolve `react` to
-      // the real npm package and try to `require()` it in a Worker (no CJS
-      // support). Object form is required — array form is silently ignored
-      // by rolldown's worker-runner.
       const aliasMap = Object.fromEntries(entries.filter(([from, to]) => from !== to))
-      // Scope optimizeDeps to client + ssr environments ONLY. Do NOT set a
-      // top-level optimizeDeps — in Vite 6+ that's effectively the client
-      // env's default but also seeps into the rsc env's `'use client'`
-      // analysis, causing flood warnings like "inconsistently optimized".
       // Dedupe `@tanstack/redact` so Vite resolves it to a single instance
       // even when multiple packages (e.g. @tanstack/react-router and user
       // code) drag it into different parts of the module graph.
       const dedupe = noExt
+      // Scope `resolve.alias` to client + ssr environments ONLY. Do NOT set
+      // a top-level alias: it would apply to the `rsc` environment too,
+      // where `@vitejs/plugin-rsc`'s vendored `react-server-dom-server`
+      // imports `react` and needs the *real* React (with the `.d` field on
+      // ReactSharedInternals that our shim deliberately doesn't have).
+      // Aliasing `react` → `@tanstack/redact` in the RSC env crashes Flight
+      // serialization. The Cloudflare vite-plugin's rolldown worker-runner
+      // also pre-scans bare specifiers via Vite's alias map (not plugin
+      // hooks), but it scans within the *ssr* environment specifically —
+      // so per-env `environments.ssr.resolve.alias` covers it. The
+      // `enforce: 'pre'` resolveId hook below already skips RSC, so the
+      // remaining concern is alias placement. Object form is required —
+      // array form is silently ignored by rolldown's worker-runner.
       return {
-        resolve: {
-          alias: aliasMap,
-          dedupe,
-        },
         environments: {
           client: {
             optimizeDeps: { exclude: excludeList },
+            resolve: { alias: aliasMap, dedupe },
           },
           ssr: {
             optimizeDeps: { exclude: excludeList },
-            resolve: { noExternal: noExt },
+            resolve: { alias: aliasMap, dedupe, noExternal: noExt },
           },
         },
         ssr: { noExternal: noExt },


### PR DESCRIPTION
## Summary

\`0.0.2\` fixed exports for the dep-pre-bundle phase. In doing so, it exposed a latent bug: \`resolve.alias\` was set at the **top level** of the Vite config, meaning it applied to *every* environment — including \`rsc\`, where \`@vitejs/plugin-rsc\`'s vendored \`react-server-dom-server\` needs the **real** React (the one with the \`.d\` field on \`ReactSharedInternals\` our shim deliberately doesn't have).

tanstack.com hit it on 3 of 4 smoke routes:
\`\`\`
TypeError: Cannot read properties of undefined (reading 'd')
  at @vitejs_plugin-rsc_vendor_react-server-dom_server__edge.js:4839
\`\`\`

The plugin's \`resolveId\` hook already returns null for the \`rsc\` env, but Vite consults top-level \`resolve.alias\` *before* the hook runs.

## Fix

Move \`resolve.alias\` and \`dedupe\` into per-environment config under \`environments.client.resolve\` and \`environments.ssr.resolve\`. The \`rsc\` env gets nothing — real React passes through. Cloudflare's vite-plugin (which makes the SSR env a workerd runtime via \`viteEnvironment: { name: 'ssr' }\`) reads its alias map from the SSR env, so tannerlinsley.com's Cloudflare flow keeps working.

## Test plan

- [x] Built 0.0.3 tarball, overlaid on tanstack.com via \`pnpm.overrides\`
- [x] All 4 smoke routes return 200 with correct titles and zero hook/hydrate/RSC errors:
  - \`/\` → 200, 193 KB
  - \`/query/latest/docs/framework/react/overview\` → 200, 559 KB
  - \`/router/latest/docs/framework/react/overview\` → 200, 470 KB
  - \`/table/latest/docs/framework/react/overview\` → 200, 412 KB
- [x] Full husky pre-commit (format + lint + tsc + smoke) passes 4/4
- [x] Screenshot-verified TanStack Query docs page renders correctly with full styling and content
- [ ] Will verify on tannerlinsley.com (Cloudflare workerd) after publish + reinstall — env-scoped alias should still cover that flow since Cloudflare's plugin uses the SSR env

Bumped to \`0.0.3\`.