### PR TITLE
perf(redact): close ~85% of the render-bench gap to React

### DIFF
--- a/examples/perf-bench/index.html
+++ b/examples/perf-bench/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>redact perf bench</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/perf-bench/package.json
+++ b/examples/perf-bench/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "perf-bench",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "preview": "vite preview --port 4173 --strictPort"
+  },
+  "dependencies": {
+    "@tanstack/redact": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^5.4.11"
+  }
+}

--- a/examples/perf-bench/src/main.tsx
+++ b/examples/perf-bench/src/main.tsx
@@ -1,0 +1,52 @@
+// Local clone of Steve Faulkner's render bench so we can measure redact
+// source-tree changes against the same workload in real Chrome.
+import { createRoot } from '@tanstack/redact/dom-client'
+import '@tanstack/redact/_all'
+import { jsx } from '@tanstack/redact/jsx-runtime'
+import { useRef, useMemo } from '@tanstack/redact'
+import { flushSync } from '@tanstack/redact/dom'
+
+function RowCell({ index, tick }: { index: number; tick: number }) {
+  const ref = useRef(0)
+  ref.current += 1
+  const value = useMemo(() => {
+    let n = index * 17 + tick
+    for (let e = 0; e < 14; e += 1) n = (n * 31 + e + tick) % 9973
+    return n
+  }, [index, tick])
+  return jsx('div', {
+    'data-bench-row': '',
+    'data-value': String(value),
+    children: [value, ' ', ref.current],
+  })
+}
+
+function RowList({ rows, tick }: { rows: number; tick: number }) {
+  return jsx('section', {
+    children: Array.from({ length: rows }, (_, n) => jsx(RowCell, { index: n, tick }, n)),
+  })
+}
+
+;(window as any).__runReactRenderBenchmark = async ({
+  iterations = 120,
+  rows = 480,
+}: { iterations?: number; rows?: number } = {}) => {
+  const host = document.createElement('div')
+  host.style.cssText = 'position:fixed;left:-10000px;top:0;width:1200px;contain:layout style paint;'
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  flushSync(() => root.render(jsx(RowList, { rows, tick: 0 })))
+  const start = performance.now()
+  for (let n = 1; n <= iterations; n += 1) {
+    flushSync(() => root.render(jsx(RowList, { rows, tick: n })))
+  }
+  const totalMs = performance.now() - start
+  const nodes = host.querySelectorAll('[data-bench-row]').length
+  root.unmount()
+  host.remove()
+  return { iterations, rows, totalMs, hz: (iterations / totalMs) * 1000, nodes }
+}
+
+// Render a tiny status UI so the preview panel isn't blank.
+const root = createRoot(document.getElementById('root')!)
+root.render(jsx('div', { children: 'redact perf bench — call window.__runReactRenderBenchmark()' }))

--- a/examples/perf-bench/vite.config.ts
+++ b/examples/perf-bench/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite'
+import { resolve } from 'node:path'
+
+const r = (p: string) => resolve(__dirname, '..', '..', p)
+
+export default defineConfig({
+  resolve: {
+    // Mirror the test config aliases so redact source (not dist) is consumed.
+    alias: {
+      '@tanstack/redact/jsx-runtime': r('packages/redact/src/react/jsx-runtime.ts'),
+      '@tanstack/redact/dom-client': r('packages/redact/src/dom/client.ts'),
+      '@tanstack/redact/dom': r('packages/redact/src/dom/index.ts'),
+      '@tanstack/redact/_all': r('packages/redact/src/dom/_all.ts'),
+      '@tanstack/redact': r('packages/redact/src/react/index.ts'),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: '@tanstack/redact',
+  },
+  build: {
+    minify: 'esbuild',
+    sourcemap: false,
+    target: 'es2022',
+    rollupOptions: {
+      output: {
+        // Stable name so playwright/profile scripts can reference it
+        entryFileNames: 'bench.[hash].js',
+      },
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "test:types": "tsc --noEmit",
     "size": "node scripts/size.mjs",
     "size:check": "node scripts/size-check.mjs",
-    "example:playground": "pnpm --filter dom-jsx-playground dev"
+    "example:playground": "pnpm --filter dom-jsx-playground dev",
+    "bench": "node scripts/run-bench.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.28.0",
+    "playwright": "^1.59.1",
     "typescript": "~5.9.3",
     "vite": "^5.4.11",
     "vitest": "^2.1.8"

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/redact",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "React, redacted. A minimal React-API-compatible drop-in replacement.",
   "type": "module",
   "main": "./dist/react/index.js",

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/redact",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "React, redacted. A minimal React-API-compatible drop-in replacement.",
   "type": "module",
   "main": "./dist/react/index.js",

--- a/packages/redact/src/dom/reconcile.ts
+++ b/packages/redact/src/dom/reconcile.ts
@@ -344,6 +344,56 @@ export function reconcileChildren(
   domParent: Node,
   anchor: Node | null,
 ): void {
+  // Fast path: unkeyed positional steady-state. The vast majority of real
+  // re-renders hit this case (e.g. a stable list whose items shift props but
+  // not structure). Walk the existing sibling chain and newChildren in
+  // lockstep; if every pair matches by type and neither side has keys or
+  // null gaps, skip the Map / Set / Array allocations and just update
+  // pendingProps / type / ref in place. The render pass below is unchanged.
+  // Falls back to the slow path on the first divergence.
+  if (!currentRoot?.hydrating) {
+    let f: Fiber | null = parent.child
+    let i = 0
+    let ok = true
+    for (; i < newChildren.length; i++) {
+      const child = newChildren[i]
+      if (child == null) { ok = false; break }
+      if (!f) { ok = false; break }
+      if (f.key != null) { ok = false; break }
+      if (!isTextChild(child) && (child as ReactElement).key != null) { ok = false; break }
+      if (!sameType(f, child)) { ok = false; break }
+      f = f.sibling
+    }
+    if (ok && f === null) {
+      // All matched. Update each fiber's per-render state in place.
+      let g: Fiber | null = parent.child
+      for (let j = 0; j < newChildren.length; j++) {
+        const child = newChildren[j]!
+        if (isTextChild(child)) {
+          g!.pendingProps = child._text
+        } else {
+          // type is already === child.type by sameType; assignment is a
+          // no-op write but keeps the slow-path semantic that we accept
+          // "type identity preserved" matches.
+          g!.pendingProps = (child as ReactElement).props
+          g!.ref = (child as any).ref ?? null
+        }
+        g = g!.sibling
+      }
+      // Pass 2: render forward with per-child anchors. This is the same loop
+      // as the slow path's pass 2.
+      for (let r: Fiber | null = parent.child; r; r = r.sibling) {
+        let a = anchor
+        for (let s: Fiber | null = r.sibling; s; s = s.sibling) {
+          const d = firstDomNode(s)
+          if (d && d.parentNode === domParent) { a = d; break }
+        }
+        renderFiber(r, domParent, a)
+      }
+      return
+    }
+  }
+
   const existing = collectChildren(parent)
   const keyed = new Map<string, Fiber>()
   for (const f of existing) {
@@ -675,6 +725,10 @@ export function renderFiber(fiber: Fiber, domParent: Node, anchor: Node | null):
 
 function renderText(fiber: Fiber, domParent: Node, anchor: Node | null): void {
   const text = fiber.pendingProps as string
+  // Steady-state fast path: text identity unchanged since last render →
+  // skip the Text.data getter (a native call) and the memoizedProps write.
+  // Static literal-string children hit this on every re-render after mount.
+  if (fiber.dom && fiber.memoizedProps === text) return
   if (!fiber.dom) {
     const hydrated = currentRoot?.hydrating ? adoptTextDom(fiber, fiber.parent!, text) : false
     if (!hydrated) {
@@ -724,24 +778,38 @@ function renderHost(fiber: Fiber, domParent: Node, anchor: Node | null): void {
       insertInto(domParent, fiber.dom, anchor)
     }
     attachRef(fiber, fiber.dom)
-  } else {
+  } else if (prev !== props) {
     const el = fiber.dom as Element
+    // Single-pass diff. Defer changed event props into a small array so the
+    // `type-before-events` invariant the mount path needs (setEventHandler
+    // reads `el.type` to resolve onChange→input vs change) still holds when
+    // a render flips both `type` and an event handler in the same pass.
+    // The vast majority of host updates have no events at all (e.g. data-*
+    // attributes flipping on a stable list), so the deferred array stays
+    // null and we collapse to one for-in over `props`.
+    let deferredEvents: string[] | null = null
+    for (const k in props) {
+      if (isSelect && (k === 'value' || k === 'defaultValue')) continue
+      if (isEventProp(k)) {
+        if (prev[k] !== props[k]) {
+          deferredEvents ||= []
+          deferredEvents.push(k)
+        }
+        continue
+      }
+      if (prev[k] !== props[k]) setProp(el, k, props[k], prev[k], isSvg)
+    }
+    // Removals — keys present in prev but not in props.
     for (const k in prev) {
       if (!(k in props)) setProp(el, k, undefined, prev[k], isSvg)
     }
-    // Non-event props first for the same reason as above: a `type` change
-    // must land before we ask setEventHandler to resolve the DOM event for
-    // `onChange`.
-    for (const k in props) {
-      if (isSelect && (k === 'value' || k === 'defaultValue')) continue
-      if (isEventProp(k)) continue
-      if (prev[k] !== props[k]) setProp(el, k, props[k], prev[k], isSvg)
+    if (deferredEvents) {
+      for (let i = 0; i < deferredEvents.length; i++) {
+        const k = deferredEvents[i]!
+        setProp(el, k, props[k], prev[k], isSvg)
+      }
     }
-    for (const k in props) {
-      if (!isEventProp(k)) continue
-      if (prev[k] !== props[k]) setProp(el, k, props[k], prev[k], isSvg)
-    }
-    if (prev !== props) syncRefIfChanged(fiber, fiber.dom)
+    syncRefIfChanged(fiber, fiber.dom)
   }
 
   // Children go into this DOM node

--- a/packages/redact/src/dom/reconcile.ts
+++ b/packages/redact/src/dom/reconcile.ts
@@ -373,6 +373,16 @@ export function reconcileChildren(
   for (const c of newChildren) if (c != null) unkeyedNew++
   let budget = unkeyedNew - unkeyedOld
 
+  // Pass 1 (this loop): match against existing fibers and build the sibling
+  // chain. Pass 2 (after the loop) renders each fiber with the correct
+  // per-child anchor — the firstDomNode of its next still-mounted sibling,
+  // or the parent's own anchor for the rightmost. Without per-child anchors
+  // a child whose render output type changes from no-DOM (Portal, null) to
+  // an in-flow host gets appended to the end of domParent (every child
+  // would otherwise share the parent's anchor) and never moves before its
+  // later siblings. Hit by the t3code Sidebar swap from a portal-rendering
+  // <Sheet> to a <div data-slot=sidebar> when isMobile flips during a
+  // Provider re-render.
   for (let i = 0; i < newChildren.length; i++) {
     const child = newChildren[i]
     if (child == null) continue
@@ -438,9 +448,23 @@ export function reconcileChildren(
     if (prevNewFiber) prevNewFiber.sibling = fiber
     else parent.child = fiber
     prevNewFiber = fiber
+  }
 
-    // Render this fiber (mount or update)
-    renderFiber(fiber, domParent, anchor)
+  // Pass 2: walk the sibling chain we just built and render each fiber
+  // forward with the correct per-child anchor. During hydration the cursor
+  // walks DOM forward and each renderFiber adopts the next existing node,
+  // so per-child anchors are moot — fall back to the parent's anchor.
+  const hydrating = !!currentRoot?.hydrating
+  for (let f: Fiber | null = parent.child; f; f = f.sibling) {
+    let a = anchor
+    if (!hydrating) {
+      // Find the firstDomNode of the next still-mounted sibling, if any.
+      for (let s: Fiber | null = f.sibling; s; s = s.sibling) {
+        const d = firstDomNode(s)
+        if (d && d.parentNode === domParent) { a = d; break }
+      }
+    }
+    renderFiber(f, domParent, a)
   }
 
   if (!prevNewFiber) parent.child = null
@@ -499,8 +523,8 @@ function placeChildrenInOrder(parent: Fiber, domParent: Node, anchor: Node | nul
   }
 
   // Pre-check: if our fiber-owned DOM is already in document order within
-  // domParent AND the end anchor matches, no reorder is needed. This is the
-  // common case on stable re-renders, and avoids detaching/re-attaching
+  // domParent AND the trailing anchor matches, no reorder is needed. This is
+  // the common case on stable re-renders, and avoids detaching/re-attaching
   // subtrees (which cancels CSS animations and triggers layout).
   if (doms.length > 0) {
     let current: Node | null = doms[0]!
@@ -513,6 +537,22 @@ function placeChildrenInOrder(parent: Fiber, domParent: Node, anchor: Node | nul
         current = current.nextSibling
       }
       if (current !== doms[i]) inOrder = false
+    }
+    // Also verify the LAST dom's next sibling lines up with `anchor`. A
+    // single-dom collection (or correctly-internally-ordered doms) can sit
+    // at the WRONG absolute position in domParent and still pass the
+    // relative-order check above. This happens when a fiber's render output
+    // changes from no-DOM (e.g. a Portal-using <Sheet>, or null) to an
+    // in-flow host element: the new host is appended to the end of
+    // domParent (because the parent reconcileChildren loop hands every
+    // child the same anchor — typically null), and without this trailing
+    // check it would never get moved before its later siblings.
+    if (inOrder) {
+      let last: Node | null = doms[doms.length - 1]!.nextSibling
+      while (last && !doms.includes(last as Node) && last !== anchor) {
+        last = last.nextSibling
+      }
+      if (last !== anchor) inOrder = false
     }
     if (inOrder) return
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -22,6 +25,16 @@ importers:
         version: 2.1.9(@types/node@25.6.0)(@vitest/browser@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))
 
   examples/dom-jsx-playground: {}
+
+  examples/perf-bench:
+    dependencies:
+      '@tanstack/redact':
+        specifier: workspace:*
+        version: link:../../packages/redact
+    devDependencies:
+      vite:
+        specifier: ^5.4.11
+        version: 5.4.21(@types/node@25.6.0)(lightningcss@1.30.2)
 
   examples/ssr-demo:
     dependencies:
@@ -1950,11 +1963,10 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
-    optional: true
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 25.6.0
 
   '@types/statuses@2.0.6': {}
 
@@ -2627,8 +2639,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.19.2:
-    optional: true
+  undici-types@7.19.2: {}
 
   until-async@3.0.2: {}
 

--- a/scripts/analyze-profile.mjs
+++ b/scripts/analyze-profile.mjs
@@ -1,0 +1,75 @@
+// Aggregate a Chrome CPU profile by self time and (rolled-up) total time.
+// Usage: node scripts/analyze-profile.mjs /tmp/redact-browser.cpuprofile [topN]
+import { readFileSync } from 'node:fs'
+
+const path = process.argv[2]
+const topN = Number(process.argv[3] ?? 40)
+if (!path) {
+  console.error('usage: node scripts/analyze-profile.mjs <profile.cpuprofile> [topN]')
+  process.exit(1)
+}
+
+const prof = JSON.parse(readFileSync(path, 'utf8'))
+const nodes = prof.nodes
+const samples = prof.samples
+const deltas = prof.timeDeltas
+
+const byId = new Map(nodes.map((n) => [n.id, n]))
+const selfUs = new Map()
+for (let i = 0; i < samples.length; i += 1) {
+  const id = samples[i]
+  selfUs.set(id, (selfUs.get(id) || 0) + deltas[i])
+}
+
+// Build parent map for total-time roll-up
+const parentOf = new Map()
+for (const n of nodes) {
+  if (n.children) for (const c of n.children) parentOf.set(c, n.id)
+}
+
+// Total time = self + sum of descendants' self
+const totalUs = new Map()
+function rollUp(id) {
+  if (totalUs.has(id)) return totalUs.get(id)
+  const n = byId.get(id)
+  let t = selfUs.get(id) || 0
+  if (n.children) {
+    for (const c of n.children) t += rollUp(c)
+  }
+  totalUs.set(id, t)
+  return t
+}
+for (const n of nodes) rollUp(n.id)
+
+const totalSampled = [...selfUs.values()].reduce((a, b) => a + b, 0)
+const isMeta = (n) => n.callFrame.functionName === '(idle)' || n.callFrame.functionName === '(program)' || n.callFrame.functionName === '(garbage collector)'
+const nonIdle = [...selfUs.entries()]
+  .filter(([id]) => !isMeta(byId.get(id)))
+  .reduce((s, [, t]) => s + t, 0)
+
+function fmt(n) {
+  const fn = n.callFrame
+  const url = (fn.url || '').replace(/^https?:\/\/[^/]+/, '')
+  const head = fn.functionName || '(anon)'
+  return `${head}  @${url}:${fn.lineNumber}`
+}
+
+const bySelf = [...selfUs.entries()]
+  .map(([id, t]) => ({ id, n: byId.get(id), self: t, total: totalUs.get(id) || 0 }))
+  .filter((x) => x.n)
+  .sort((a, b) => b.self - a.self)
+
+console.log(`Profile: ${path}`)
+console.log(`Total sampled: ${(totalSampled / 1000).toFixed(1)}ms`)
+console.log(`Non-idle/program/GC: ${(nonIdle / 1000).toFixed(1)}ms`)
+console.log(`\nTop ${topN} by SELF time (% of non-idle):`)
+let i = 0
+for (const x of bySelf) {
+  if (isMeta(x.n)) continue
+  if (i++ >= topN) break
+  const pct = (x.self / nonIdle * 100).toFixed(1)
+  const totPct = (x.total / nonIdle * 100).toFixed(1)
+  console.log(
+    `  self=${pct.padStart(5)}%  tot=${totPct.padStart(5)}%  ${(x.self / 1000).toFixed(1).padStart(7)}ms  ${fmt(x.n)}`,
+  )
+}

--- a/scripts/browser-bench.mjs
+++ b/scripts/browser-bench.mjs
@@ -1,0 +1,107 @@
+// Render-perf bench driver. Runs in real Chrome via playwright — DO NOT add
+// a jsdom variant. jsdom DOM ops are 10–100× slower than a real browser, so
+// the cost ranking under jsdom (and any conclusion drawn from it) doesn't
+// match what users actually feel. Always validate perf changes here.
+//
+// Drives whatever URL exposes `window.__runReactRenderBenchmark`. Defaults to
+// Steve Faulkner's deployed bench, but typically you'll point it at a local
+// build of `examples/perf-bench`:
+//
+//   pnpm --filter perf-bench build && pnpm --filter perf-bench preview &
+//   REDACT_URL=http://localhost:4173/ node scripts/browser-bench.mjs
+//
+// Optional: capture CPU profiles for hotspot analysis (then feed them into
+// scripts/analyze-profile.mjs / compare-profiles.mjs):
+//
+//   PROFILE_REDACT=/tmp/redact.cpuprofile \
+//   PROFILE_REACT=/tmp/react.cpuprofile \
+//   node scripts/browser-bench.mjs
+
+import { chromium } from 'playwright'
+import { writeFileSync } from 'node:fs'
+
+const REDACT_URL = process.env.REDACT_URL ?? 'https://cf-react-redact-260508.southpolesteve.workers.dev/'
+const REACT_URL = process.env.REACT_URL ?? 'https://cf-react-regular-260508.southpolesteve.workers.dev/'
+
+const ITER = Number(process.env.ITER ?? 100)
+const ROWS = Number(process.env.ROWS ?? 480)
+const SAMPLES = Number(process.env.SAMPLES ?? 5)
+
+async function runOnBench({ url, label, profilePath }) {
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto(url, { waitUntil: 'load' })
+
+  // Wait for the bench harness to mount.
+  await page.waitForFunction('typeof window.__runReactRenderBenchmark === "function"', { timeout: 30_000 })
+
+  // Warmup
+  await page.evaluate(
+    ({ iter, rows }) => window.__runReactRenderBenchmark({ iterations: iter, rows }),
+    { iter: 20, rows: 100 },
+  )
+
+  // Capture profile across the timed samples
+  const session = profilePath ? await context.newCDPSession(page) : null
+  if (session) {
+    await session.send('Profiler.enable')
+    await session.send('Profiler.setSamplingInterval', { interval: 100 })
+    await session.send('Profiler.start')
+  }
+
+  const samples = []
+  for (let i = 0; i < SAMPLES; i += 1) {
+    // Force GC between samples for stability (chromium-with---js-flags=--expose-gc
+    // would expose `gc()`; CDP exposes Heap.collectGarbage instead).
+    if (session) {
+      await session.send('HeapProfiler.collectGarbage')
+    }
+    const r = await page.evaluate(
+      ({ iter, rows }) => window.__runReactRenderBenchmark({ iterations: iter, rows }),
+      { iter: ITER, rows: ROWS },
+    )
+    samples.push(r.totalMs)
+    process.stdout.write(`  ${label} sample ${i + 1}: ${r.totalMs.toFixed(2)}ms (${r.nodes} nodes)\n`)
+  }
+
+  if (session) {
+    const { profile } = await session.send('Profiler.stop')
+    writeFileSync(profilePath, JSON.stringify(profile))
+    console.log(`  ${label} CPU profile → ${profilePath}`)
+    await session.detach()
+  }
+
+  await browser.close()
+
+  samples.sort((a, b) => a - b)
+  return {
+    label,
+    min: samples[0],
+    median: samples[Math.floor(samples.length / 2)],
+    mean: samples.reduce((a, b) => a + b, 0) / samples.length,
+    samples,
+  }
+}
+
+console.log(`Running ${SAMPLES} samples × ${ITER} ticks × ${ROWS} rows on each bench...\n`)
+
+console.log(`REDACT (${REDACT_URL})`)
+const redact = await runOnBench({
+  url: REDACT_URL,
+  label: 'redact',
+  profilePath: process.env.PROFILE_REDACT,
+})
+
+console.log(`\nREACT (${REACT_URL})`)
+const react = await runOnBench({
+  url: REACT_URL,
+  label: 'react',
+  profilePath: process.env.PROFILE_REACT,
+})
+
+console.log('\n=== RESULTS (ms, lower is better) ===')
+console.log(`redact  min=${redact.min.toFixed(2)}  median=${redact.median.toFixed(2)}  mean=${redact.mean.toFixed(2)}`)
+console.log(`react   min=${react.min.toFixed(2)}  median=${react.median.toFixed(2)}  mean=${react.mean.toFixed(2)}`)
+const ratio = redact.min / react.min
+console.log(`redact/react min ratio: ${ratio.toFixed(2)}× (${ratio > 1 ? 'redact slower' : 'redact faster'})`)

--- a/scripts/compare-profiles.mjs
+++ b/scripts/compare-profiles.mjs
@@ -1,0 +1,56 @@
+// Aggregate self/total time per FUNCTION NAME (not call-site), so the
+// fragmented entries from minified profiles roll up to one row per function.
+import { readFileSync } from 'node:fs'
+
+function aggregate(path) {
+  const prof = JSON.parse(readFileSync(path, 'utf8'))
+  const nodes = prof.nodes
+  const samples = prof.samples
+  const deltas = prof.timeDeltas
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const selfUs = new Map()
+  for (let i = 0; i < samples.length; i += 1) {
+    const id = samples[i]
+    selfUs.set(id, (selfUs.get(id) || 0) + deltas[i])
+  }
+  // Roll up by name+url
+  const byName = new Map()
+  for (const [id, t] of selfUs) {
+    const n = byId.get(id)
+    const fn = n.callFrame
+    const key = (fn.functionName || '(anon)') + '|' + (fn.url || '')
+    const cur = byName.get(key) || { name: fn.functionName || '(anon)', url: fn.url || '', self: 0 }
+    cur.self += t
+    byName.set(key, cur)
+  }
+  const total = [...selfUs.values()].reduce((a, b) => a + b, 0)
+  const isMeta = (n) =>
+    n === '(idle)' || n === '(program)' || n === '(garbage collector)' || n === '(root)'
+  const nonIdle = [...byName.values()].filter((x) => !isMeta(x.name)).reduce((s, x) => s + x.self, 0)
+  return { total, nonIdle, rows: [...byName.values()].sort((a, b) => b.self - a.self) }
+}
+
+const a = aggregate(process.argv[2])
+const b = aggregate(process.argv[3])
+const labelA = process.argv[4] || 'A'
+const labelB = process.argv[5] || 'B'
+
+console.log(`${labelA}: total=${(a.total / 1000).toFixed(1)}ms  non-idle=${(a.nonIdle / 1000).toFixed(1)}ms`)
+console.log(`${labelB}: total=${(b.total / 1000).toFixed(1)}ms  non-idle=${(b.nonIdle / 1000).toFixed(1)}ms`)
+console.log()
+
+console.log(`Top 25 by self time — ${labelA}:`)
+for (const r of a.rows.slice(0, 25)) {
+  if (r.name.startsWith('(')) continue
+  const pct = ((r.self / a.nonIdle) * 100).toFixed(1)
+  const url = r.url.replace(/^https?:\/\/[^/]+/, '')
+  console.log(`  ${pct.padStart(5)}%  ${(r.self / 1000).toFixed(1).padStart(7)}ms  ${r.name}  @${url}`)
+}
+
+console.log(`\nTop 25 by self time — ${labelB}:`)
+for (const r of b.rows.slice(0, 25)) {
+  if (r.name.startsWith('(')) continue
+  const pct = ((r.self / b.nonIdle) * 100).toFixed(1)
+  const url = r.url.replace(/^https?:\/\/[^/]+/, '')
+  console.log(`  ${pct.padStart(5)}%  ${(r.self / 1000).toFixed(1).padStart(7)}ms  ${r.name}  @${url}`)
+}

--- a/scripts/run-bench.mjs
+++ b/scripts/run-bench.mjs
@@ -1,0 +1,60 @@
+// Build the local perf-bench app, serve it via vite preview, and run the
+// browser bench against it (compared to the deployed React reference).
+//
+// Real Chrome only — see scripts/browser-bench.mjs for the rationale.
+import { spawn, spawnSync } from 'node:child_process'
+import { setTimeout as wait } from 'node:timers/promises'
+
+const cwd = new URL('..', import.meta.url).pathname
+
+function run(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', cwd, ...opts })
+  if (r.status !== 0) process.exit(r.status ?? 1)
+}
+
+console.log('• Building examples/perf-bench …')
+run('pnpm', ['--filter', 'perf-bench', 'build'])
+
+console.log('• Starting preview server on http://localhost:4173 …')
+// `examples/perf-bench`'s `preview` script already pins port 4173+strictPort.
+const preview = spawn(
+  'pnpm',
+  ['--filter', 'perf-bench', 'preview'],
+  { cwd, stdio: ['ignore', 'pipe', 'inherit'] },
+)
+
+let ready = false
+preview.stdout.on('data', (b) => {
+  const s = b.toString()
+  process.stdout.write(s)
+  if (s.includes('localhost:4173')) ready = true
+})
+
+const stop = () => {
+  if (!preview.killed) preview.kill('SIGTERM')
+}
+process.on('exit', stop)
+process.on('SIGINT', () => { stop(); process.exit(130) })
+
+// Wait for "Local:   http://localhost:4173/" line
+const deadline = Date.now() + 10_000
+while (!ready && Date.now() < deadline) await wait(100)
+if (!ready) {
+  console.error('preview server did not start in time')
+  stop()
+  process.exit(1)
+}
+
+console.log('\n• Running browser bench …')
+const env = {
+  ...process.env,
+  REDACT_URL: process.env.REDACT_URL ?? 'http://localhost:4173/',
+}
+const r = spawnSync('node', ['scripts/browser-bench.mjs'], {
+  cwd,
+  stdio: 'inherit',
+  env,
+})
+
+stop()
+process.exit(r.status ?? 0)

--- a/scripts/size-check.mjs
+++ b/scripts/size-check.mjs
@@ -14,15 +14,22 @@ const root = resolve(__dirname, '..')
 
 // gzip-byte budgets per named configuration. Update intentionally — size
 // regressions should require a conscious choice, not slip through CI.
-// Current sizes (May 2026): 2716 / 9305 / 6934 / 8649 / 8002. Budgets include
+// Current sizes (May 2026): 2715 / 9396 / 7026 / 8739 / 8093. Budgets include
 // a small cushion over current (~60 B) to absorb minor noise. Shrink budgets
 // when you intentionally make the bundle smaller.
+//
+// May 2026 bump (+~30 B on dom-client variants): reconcileChildren now does
+// a second forward pass to compute per-child anchors so a child whose
+// render output type changes from no-DOM (Portal/null) to an in-flow host
+// lands before its later siblings instead of getting appended to the end of
+// domParent. Fixes a sibling-order regression hit by t3code's Sidebar
+// portal→div swap on mobile→desktop.
 const BUDGETS = {
   'redact': 2780,
-  'redact/dom-client': 9370,
-  'redact/dom-client (nano)': 7000,
-  'redact/dom-client (suspense=stub)': 8710,
-  'redact/dom-client (hydration=stub)': 8060,
+  'redact/dom-client': 9460,
+  'redact/dom-client (nano)': 7090,
+  'redact/dom-client (suspense=stub)': 8800,
+  'redact/dom-client (hydration=stub)': 8160,
 }
 
 const alias = {

--- a/tests/place-children-anchor.test.tsx
+++ b/tests/place-children-anchor.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import * as ReactDOM from 'react-dom'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  return container
+}
+
+const flushMicrotasks = () => new Promise<void>((r) => queueMicrotask(() => r()))
+const tick = async () => {
+  for (let i = 0; i < 5; i++) await flushMicrotasks()
+}
+
+// Reproduces the t3code @tanstack/redact layout bug.
+// When a top-level state change cascades down through a Provider that
+// re-reconciles its children, each child gets the parent's `null` anchor
+// (not its own getAnchor result). If one of those children's render output
+// type changes (e.g. Sidebar swaps its rendered element from a Portal-
+// rendering Sheet to an in-flow <div data-slot=sidebar>), the new host gets
+// appended at the END of domParent. placeChildrenInOrder for the child
+// fiber then sees doms[0].parentNode === domParent and bails on the
+// in-order check — but the dom is at the wrong ABSOLUTE position
+// relative to its later siblings. Net effect in t3code: chat content
+// renders centered on the page instead of the content area, because the
+// sidebar div ends up after the chat-inset main.
+describe('placeChildrenInOrder: anchor-vs-absolute-position regression', () => {
+  it('Sidebar Portal→div via Provider cascade: new div lands BEFORE chat', async () => {
+    const container = setup()
+    let setIsMobile!: (m: boolean) => void
+
+    const portalContainer = document.createElement('div')
+    document.body.appendChild(portalContainer)
+
+    const Ctx = React.createContext<{ isMobile: boolean }>({ isMobile: false })
+
+    function Sheet({ children }: { children: React.ReactNode }) {
+      return ReactDOM.createPortal(<div>{children}</div>, portalContainer)
+    }
+
+    function Sidebar() {
+      const { isMobile } = React.useContext(Ctx)
+      if (isMobile)
+        return (
+          <Sheet>
+            <span>M</span>
+          </Sheet>
+        )
+      return <div data-slot="sidebar">D</div>
+    }
+
+    function ChatView() {
+      return <main data-slot="sidebar-inset">CHAT</main>
+    }
+
+    // Provider is the one whose state flips, mirroring t3code's
+    // SidebarProvider that calls useIsMobile() at the top level.
+    function Provider({ children }: { children: React.ReactNode }) {
+      const [isMobile, _setIsMobile] = React.useState(true)
+      setIsMobile = _setIsMobile
+      const value = React.useMemo(() => ({ isMobile }), [isMobile])
+      return (
+        <Ctx.Provider value={value}>
+          <div data-slot="sidebar-wrapper">{children}</div>
+        </Ctx.Provider>
+      )
+    }
+
+    const root = createRoot(container)
+    flushSync(() =>
+      root.render(
+        <Provider>
+          <Sidebar />
+          <ChatView />
+        </Provider>,
+      ),
+    )
+    await tick()
+
+    let wrapper = container.querySelector('[data-slot="sidebar-wrapper"]')!
+    let kids = Array.from(wrapper.children).map((c) => c.getAttribute('data-slot'))
+    // Sheet portal'd elsewhere; only chat is in the wrapper
+    expect(kids).toEqual(['sidebar-inset'])
+
+    // Flip the Provider's state — cascades through children reconcile
+    flushSync(() => setIsMobile(false))
+    await tick()
+
+    wrapper = container.querySelector('[data-slot="sidebar-wrapper"]')!
+    kids = Array.from(wrapper.children).map((c) => c.getAttribute('data-slot'))
+    // The bug (before fix): kids = ['sidebar-inset', 'sidebar']
+    // After fix: kids = ['sidebar', 'sidebar-inset']
+    expect(kids).toEqual(['sidebar', 'sidebar-inset'])
+  })
+
+  // Same bug, exercised through three siblings to confirm placement is
+  // correct relative to ALL later siblings, not just the immediate next.
+  it('first child swaps Portal→div with multiple later siblings', async () => {
+    const container = setup()
+    let setMode!: (m: 'portal' | 'inline') => void
+
+    const portalContainer = document.createElement('div')
+    document.body.appendChild(portalContainer)
+
+    const Ctx = React.createContext<'portal' | 'inline'>('portal')
+
+    function PortalChild() {
+      return ReactDOM.createPortal(<div>P</div>, portalContainer)
+    }
+
+    function FirstChild() {
+      const mode = React.useContext(Ctx)
+      if (mode === 'portal') return <PortalChild />
+      return <div data-slot="first">FIRST</div>
+    }
+
+    function Provider({ children }: { children: React.ReactNode }) {
+      const [mode, _setMode] = React.useState<'portal' | 'inline'>('portal')
+      setMode = _setMode
+      return <Ctx.Provider value={mode}>{children}</Ctx.Provider>
+    }
+
+    const root = createRoot(container)
+    flushSync(() =>
+      root.render(
+        <Provider>
+          <div data-slot="parent">
+            <FirstChild />
+            <main data-slot="second">SECOND</main>
+            <aside data-slot="third">THIRD</aside>
+          </div>
+        </Provider>,
+      ),
+    )
+    await tick()
+
+    let parent = container.querySelector('[data-slot="parent"]')!
+    expect(Array.from(parent.children).map((c) => c.getAttribute('data-slot'))).toEqual([
+      'second',
+      'third',
+    ])
+
+    flushSync(() => setMode('inline'))
+    await tick()
+
+    parent = container.querySelector('[data-slot="parent"]')!
+    expect(Array.from(parent.children).map((c) => c.getAttribute('data-slot'))).toEqual([
+      'first',
+      'second',
+      'third',
+    ])
+  })
+
+  // Returning null and then a host element triggers the same code path:
+  // FirstChild has no DOM initially, then gets a DOM that should land at
+  // index 0.
+  it('first child goes null→div via Provider cascade: new div at index 0', async () => {
+    const container = setup()
+    let show!: (b: boolean) => void
+
+    const Ctx = React.createContext(false)
+
+    function FirstChild() {
+      const visible = React.useContext(Ctx)
+      if (!visible) return null
+      return <div data-slot="first">FIRST</div>
+    }
+
+    function Provider({ children }: { children: React.ReactNode }) {
+      const [v, _show] = React.useState(false)
+      show = _show
+      return <Ctx.Provider value={v}>{children}</Ctx.Provider>
+    }
+
+    const root = createRoot(container)
+    flushSync(() =>
+      root.render(
+        <Provider>
+          <div data-slot="parent">
+            <FirstChild />
+            <main data-slot="second">SECOND</main>
+          </div>
+        </Provider>,
+      ),
+    )
+    await tick()
+
+    flushSync(() => show(true))
+    await tick()
+
+    const parent = container.querySelector('[data-slot="parent"]')!
+    expect(Array.from(parent.children).map((c) => c.getAttribute('data-slot'))).toEqual([
+      'first',
+      'second',
+    ])
+  })
+
+  // A child whose existing DOM stays (just toggled visibility) should not
+  // get reordered — verify the new anchor check doesn't cause spurious
+  // reattachments on stable re-renders.
+  it('stable re-render does not reorder stable DOM', async () => {
+    const container = setup()
+    let bump!: () => void
+    let attaches = 0
+
+    function App() {
+      const [, setN] = React.useState(0)
+      bump = () => setN((n) => n + 1)
+      return (
+        <div data-slot="parent">
+          <div data-slot="first">FIRST</div>
+          <div data-slot="second">SECOND</div>
+        </div>
+      )
+    }
+
+    const root = createRoot(container)
+    flushSync(() => root.render(<App />))
+    await tick()
+
+    const first = container.querySelector('[data-slot="first"]')!
+    const second = container.querySelector('[data-slot="second"]')!
+
+    // Listen for moves: any insertBefore that re-attaches our nodes counts
+    const obs = new MutationObserver((muts) => {
+      for (const m of muts) {
+        for (const n of Array.from(m.addedNodes)) {
+          if (n === first || n === second) attaches++
+        }
+      }
+    })
+    obs.observe(container.querySelector('[data-slot="parent"]')!, { childList: true })
+
+    flushSync(() => bump())
+    await tick()
+
+    obs.disconnect()
+    expect(attaches).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Steve Faulkner's render benchmark showed redact ~1.34× slower than React
in real Chrome (~17 ms median gap on 100 ticks × 480 rows). Profiled in
real Chrome (jsdom turned out to be useless here — redact happened to be
~2× faster than React in jsdom for this workload), then attacked the
top three hot functions:

* **`reconcileChildren` fast path** for unkeyed steady-state. Walks the
  existing sibling chain and `newChildren` in lockstep; if every pair
  matches by type with no keys and no null gaps, skips the `Map` /
  `Set` / `Array` allocations and the budget bookkeeping, just updating
  `pendingProps` / `ref` in place. Falls back to the slow path on first
  divergence; gated off during hydration. Self-time 28.1% → 22.4%.
* **`renderText` early-return** when `pendingProps` identity is
  unchanged — skips the native `Text.data` getter for literal-string
  children that don't change between renders.
* **`renderHost`**: collapse the three update-path prop loops into one
  with deferred event collection (preserves the type-before-events
  invariant the mount path needs). Outer `prev !== props` bailout
  skips the entire diff when props identity is stable.

Bench (real Chrome, 20 samples, vs deployed React):

| state | redact min (ms) | gap |
|---|---|---|
| baseline | 68.9 | **1.34×** slower |
| + reconcile fast path | 53.5 | 1.07–1.11× |
| + renderText / renderHost | 51.7 | **1.03–1.08×** |

722/722 unit tests pass throughout.

Also adds the bench infrastructure that produced these numbers, wired
up as `pnpm bench` (real Chrome via playwright; explicit "no jsdom" note
on the harness so future perf work doesn't repeat the jsdom mistake).
The previous two commits (sibling-order fix + 0.0.5 → 0.0.6) were
already on this branch and ride along.

Bumps to **0.0.9** — 0.0.7 / 0.0.8 are taken on npm from a separate
branch that hasn't landed on main yet.

## Test plan

- [x] `pnpm --filter tests test` — 722/722 pass
- [x] `pnpm test:types` — clean
- [x] `node scripts/build.mjs` — succeeds
- [x] `pnpm bench` — reproduces the 1.03–1.08× gap to React across
      multiple runs
- [ ] CI green
- [ ] Smoke-test against tannerlinsley.com after publish