### PR TITLE
perf(redact): four more render-bench wins — now ~18% faster than React

### DIFF
--- a/examples/perf-bench/src/main.tsx
+++ b/examples/perf-bench/src/main.tsx
@@ -5,6 +5,7 @@ import '@tanstack/redact/_all'
 import { jsx } from '@tanstack/redact/jsx-runtime'
 import { useRef, useMemo } from '@tanstack/redact'
 import { flushSync } from '@tanstack/redact/dom'
+import './workloads'
 
 function RowCell({ index, tick }: { index: number; tick: number }) {
   const ref = useRef(0)

--- a/examples/perf-bench/src/workloads.ts
+++ b/examples/perf-bench/src/workloads.ts
@@ -1,0 +1,138 @@
+// Additional render workloads beyond the canonical RowList × RowCell bench.
+// Each is exposed as `window.__bench<Name>` returning {totalMs, ...} so the
+// playwright driver can hit it via `page.evaluate(...)`.
+//
+// All workloads share the same shape:
+//   - mount once
+//   - run `iterations` flushSync renders
+//   - tear down
+//   - return totalMs / nodes / etc
+//
+// The point isn't to crown a winner on every workload — it's to make sure
+// fixes targeted at the canonical bench haven't regressed adjacent patterns
+// that exercise different parts of the reconciler.
+import { createRoot } from '@tanstack/redact/dom-client'
+import { jsx } from '@tanstack/redact/jsx-runtime'
+import { useRef, useMemo, useState } from '@tanstack/redact'
+import { flushSync } from '@tanstack/redact/dom'
+
+// Helper: mount, run N renders, tear down, time the loop.
+function timed<P>(
+  Component: (p: P) => unknown,
+  initialProps: P,
+  nextProps: (i: number) => P,
+  iterations: number,
+) {
+  const host = document.createElement('div')
+  host.style.cssText = 'position:fixed;left:-10000px;top:0;width:1200px;contain:layout style paint;'
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  flushSync(() => root.render(jsx(Component as any, initialProps as any)))
+  const start = performance.now()
+  for (let i = 1; i <= iterations; i += 1) {
+    flushSync(() => root.render(jsx(Component as any, nextProps(i) as any)))
+  }
+  const totalMs = performance.now() - start
+  const nodes = host.querySelectorAll('*').length
+  root.unmount()
+  host.remove()
+  return { iterations, totalMs, nodes }
+}
+
+// ---------------------------------------------------------------------------
+// 1. KEYED REORDER — forces the slow path's keyed-Map branch.
+//    Same item set every iteration, but shuffled. Each item has a stable key.
+// ---------------------------------------------------------------------------
+function shuffle(seed: number, n: number): number[] {
+  const arr = Array.from({ length: n }, (_, i) => i)
+  let s = seed
+  for (let i = n - 1; i > 0; i -= 1) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    const j = s % (i + 1)
+    ;[arr[i], arr[j]] = [arr[j]!, arr[i]!]
+  }
+  return arr
+}
+
+function KeyedItem({ id }: { id: number }) {
+  return jsx('div', { 'data-key': id, children: id })
+}
+
+function KeyedList({ order }: { order: number[] }) {
+  return jsx('section', {
+    children: order.map((id) => jsx(KeyedItem, { id }, id)),
+  })
+}
+
+;(window as any).__benchKeyedReorder = ({ iterations = 100, rows = 240 } = {}) =>
+  timed(
+    KeyedList,
+    { order: shuffle(0, rows) },
+    (i) => ({ order: shuffle(i, rows) }),
+    iterations,
+  )
+
+// ---------------------------------------------------------------------------
+// 2. MOUNT/UNMOUNT — alternates between empty and full lists. Tests the
+//    create/remove path (no fast-path help — every render diverges).
+// ---------------------------------------------------------------------------
+function MountUnmount({ show, count }: { show: boolean; count: number }) {
+  return jsx('section', {
+    children: show
+      ? Array.from({ length: count }, (_, n) =>
+          jsx('div', { 'data-row': n, children: n }, n),
+        )
+      : null,
+  })
+}
+
+;(window as any).__benchMountUnmount = ({ iterations = 100, rows = 200 } = {}) =>
+  timed(
+    MountUnmount,
+    { show: true, count: rows },
+    (i) => ({ show: i % 2 === 0, count: rows }),
+    iterations,
+  )
+
+// ---------------------------------------------------------------------------
+// 3. DEEP TREE — many levels of Function fibers, one host leaf. Exercises
+//    the renderFunction / hooks dispatcher dispatch on every render.
+// ---------------------------------------------------------------------------
+function Depth({ remaining, tick }: { remaining: number; tick: number }): any {
+  if (remaining === 0) {
+    return jsx('div', { 'data-leaf': '', children: tick })
+  }
+  return jsx(Depth, { remaining: remaining - 1, tick })
+}
+
+;(window as any).__benchDeepTree = ({ iterations = 100, depth = 60 } = {}) =>
+  timed(
+    Depth,
+    { remaining: depth, tick: 0 },
+    (i) => ({ remaining: depth, tick: i }),
+    iterations,
+  )
+
+// ---------------------------------------------------------------------------
+// 4. STATE CHURN — many siblings each holding their own useState; each
+//    render flips ALL of them. Measures hook dispatch + setState path
+//    (though we drive via top-level rerender so setState isn't fired).
+//    Real use of useState would re-enter scheduler; we simulate the cost
+//    by re-rendering parent with new tick that propagates as a prop.
+// ---------------------------------------------------------------------------
+function StateCell({ tick }: { tick: number }) {
+  const [x] = useState(0)
+  const ref = useRef(0)
+  ref.current += 1
+  const v = useMemo(() => x + tick, [x, tick])
+  return jsx('span', { children: [v, ' ', ref.current] })
+}
+
+function StateRow({ rows, tick }: { rows: number; tick: number }) {
+  return jsx('section', {
+    children: Array.from({ length: rows }, (_, n) => jsx(StateCell, { tick }, n)),
+  })
+}
+
+;(window as any).__benchStateChurn = ({ iterations = 100, rows = 240 } = {}) =>
+  timed(StateRow, { rows, tick: 0 }, (i) => ({ rows, tick: i }), iterations)

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/redact",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "React, redacted. A minimal React-API-compatible drop-in replacement.",
   "type": "module",
   "main": "./dist/react/index.js",

--- a/packages/redact/src/dom/dispatcher.ts
+++ b/packages/redact/src/dom/dispatcher.ts
@@ -50,7 +50,17 @@ function depsEqual(
   return true
 }
 
+// Singleton — every method reads render context via ReactSharedInternals,
+// and per-hook closures live on the hook itself, so nothing is render-local
+// to capture. Allocating a fresh wrapper + 17 method closures per function-
+// component render was pure GC pressure.
+const DISPATCHER = makeDispatcherImpl()
+
 export function makeDispatcher() {
+  return DISPATCHER
+}
+
+function makeDispatcherImpl() {
   return {
     useState<S>(initial: S | (() => S)) {
       return this.useReducer<S, S | ((p: S) => S)>(

--- a/packages/redact/src/dom/reconcile.ts
+++ b/packages/redact/src/dom/reconcile.ts
@@ -209,20 +209,15 @@ function rerenderFiber(fiber: Fiber, root: FiberRoot): void {
 // Element → children normalization
 // ---------------------------------------------------------------------------
 
-type TextChild = { _text: string }
-type NormalizedChild = ReactElement | TextChild | null
+// Text children pass through as raw strings — no wrapper. The previous
+// `{_text: string}` shape allocated tens of thousands of objects per
+// stable-list re-render and dominated minor-GC pressure. `typeof === 'string'`
+// is also robust to RSC renderable proxies (which have `has` traps that
+// would fool a `'_text' in child` predicate but can't fool `typeof`).
+type NormalizedChild = ReactElement | string | null
 
-// NEVER use `'_text' in child` to distinguish text wrappers from elements.
-// TanStack's RSC renderable proxies (createRscProxy with renderable: true) are
-// Proxy wrappers around real React elements whose `has` trap returns `true`
-// for ANY string key — so `'_text' in rscProxy` is TRUE even though the proxy
-// is an element. That misidentification set a Text fiber's `pendingProps` to
-// `child._text` (another chained RSC proxy), which then rendered as
-// `[object Object]` when createTextNode stringified the element. React
-// elements always carry `$$typeof`; our text wrapper never does — so the
-// presence of `$$typeof` is the invariant we rely on.
-function isTextChild(child: Exclude<NormalizedChild, null>): child is TextChild {
-  return (child as any).$$typeof === undefined
+function isTextChild(child: Exclude<NormalizedChild, null>): child is string {
+  return typeof child === 'string'
 }
 
 export function childrenToArray(children: ReactNode): NormalizedChild[] {
@@ -233,11 +228,15 @@ export function childrenToArray(children: ReactNode): NormalizedChild[] {
 
 function pushChildren(node: ReactNode, out: NormalizedChild[]): void {
   if (node == null || typeof node === 'boolean') return
-  if (typeof node === 'string' || typeof node === 'number') {
+  if (typeof node === 'string') {
     // Empty strings render no text node (matches React + the `<!-- -->`
     // separator elision on the SSR side so server/client agree).
     if (node === '') return
-    out.push({ _text: '' + node })
+    out.push(node)
+    return
+  }
+  if (typeof node === 'number') {
+    out.push('' + node)
     return
   }
   if (Array.isArray(node)) {
@@ -298,7 +297,7 @@ function fiberFromChild(child: NormalizedChild, parent: Fiber): Fiber {
   if (!child) return createFiber(FiberTag.Fragment, null, null)
   if (isTextChild(child)) {
     const f = createFiber(FiberTag.Text, null, null)
-    f.pendingProps = child._text
+    f.pendingProps = child
     f.parent = parent
     return f
   }
@@ -344,44 +343,31 @@ export function reconcileChildren(
   domParent: Node,
   anchor: Node | null,
 ): void {
-  // Fast path: unkeyed positional steady-state. The vast majority of real
-  // re-renders hit this case (e.g. a stable list whose items shift props but
-  // not structure). Walk the existing sibling chain and newChildren in
-  // lockstep; if every pair matches by type and neither side has keys or
-  // null gaps, skip the Map / Set / Array allocations and just update
-  // pendingProps / type / ref in place. The render pass below is unchanged.
-  // Falls back to the slow path on the first divergence.
+  // Fast path: unkeyed positional steady-state. Walk the existing sibling
+  // chain and newChildren in lockstep, validating AND committing in one pass.
+  // On any divergence we fall back to the slow path, which rebuilds the
+  // sibling chain anyway — partial pendingProps writes are idempotent.
+  // Skips the Map / Set / existing-array allocation entirely.
   if (!currentRoot?.hydrating) {
     let f: Fiber | null = parent.child
-    let i = 0
     let ok = true
-    for (; i < newChildren.length; i++) {
+    for (let i = 0; i < newChildren.length; i++) {
       const child = newChildren[i]
-      if (child == null) { ok = false; break }
-      if (!f) { ok = false; break }
-      if (f.key != null) { ok = false; break }
-      if (!isTextChild(child) && (child as ReactElement).key != null) { ok = false; break }
-      if (!sameType(f, child)) { ok = false; break }
+      if (child == null || !f || f.key != null) { ok = false; break }
+      if (typeof child === 'string') {
+        if (f.tag !== FiberTag.Text) { ok = false; break }
+        f.pendingProps = child
+      } else {
+        if ((child as ReactElement).key != null) { ok = false; break }
+        if (f.type !== (child as ReactElement).type) { ok = false; break }
+        f.pendingProps = (child as ReactElement).props
+        f.ref = (child as any).ref ?? null
+      }
       f = f.sibling
     }
     if (ok && f === null) {
-      // All matched. Update each fiber's per-render state in place.
-      let g: Fiber | null = parent.child
-      for (let j = 0; j < newChildren.length; j++) {
-        const child = newChildren[j]!
-        if (isTextChild(child)) {
-          g!.pendingProps = child._text
-        } else {
-          // type is already === child.type by sameType; assignment is a
-          // no-op write but keeps the slow-path semantic that we accept
-          // "type identity preserved" matches.
-          g!.pendingProps = (child as ReactElement).props
-          g!.ref = (child as any).ref ?? null
-        }
-        g = g!.sibling
-      }
-      // Pass 2: render forward with per-child anchors. This is the same loop
-      // as the slow path's pass 2.
+      // Pass 2: render forward with per-child anchors. Identical to the slow
+      // path's pass 2.
       for (let r: Fiber | null = parent.child; r; r = r.sibling) {
         let a = anchor
         for (let s: Fiber | null = r.sibling; s; s = s.sibling) {
@@ -481,7 +467,7 @@ export function reconcileChildren(
       claimed.add(match)
       fiber = match
       if (isTextChild(child!)) {
-        fiber.pendingProps = child._text
+        fiber.pendingProps = child
       } else {
         fiber.type = (child as ReactElement).type
         fiber.pendingProps = (child as ReactElement).props
@@ -725,9 +711,7 @@ export function renderFiber(fiber: Fiber, domParent: Node, anchor: Node | null):
 
 function renderText(fiber: Fiber, domParent: Node, anchor: Node | null): void {
   const text = fiber.pendingProps as string
-  // Steady-state fast path: text identity unchanged since last render →
-  // skip the Text.data getter (a native call) and the memoizedProps write.
-  // Static literal-string children hit this on every re-render after mount.
+  // Identity-unchanged fast path: skip the native Text.data write entirely.
   if (fiber.dom && fiber.memoizedProps === text) return
   if (!fiber.dom) {
     const hydrated = currentRoot?.hydrating ? adoptTextDom(fiber, fiber.parent!, text) : false
@@ -735,7 +719,9 @@ function renderText(fiber: Fiber, domParent: Node, anchor: Node | null): void {
       fiber.dom = document.createTextNode(text)
       insertInto(domParent, fiber.dom, anchor)
     }
-  } else if ((fiber.dom as Text).data !== text) {
+  } else {
+    // Past the fast path, and adoptTextDom already realigned `.data` on
+    // hydration — `.data !== text` here is guaranteed, so write directly.
     ;(fiber.dom as Text).data = text
   }
   fiber.memoizedProps = text

--- a/scripts/multi-bench.mjs
+++ b/scripts/multi-bench.mjs
@@ -1,0 +1,52 @@
+// Multi-workload bench: runs the canonical RowList bench plus a few other
+// patterns (keyed reorder, mount/unmount, deep tree, state churn) to make
+// sure perf changes targeted at one workload don't regress others.
+//
+// Local-only — runs the in-tree bench app (built + previewed). Real Chrome.
+import { chromium } from 'playwright'
+
+const URL = process.env.URL ?? 'http://localhost:4173/'
+const SAMPLES = Number(process.env.SAMPLES ?? 10)
+
+const WORKLOADS = [
+  { name: 'canonical (480 rows × 100 ticks)', fn: '__runReactRenderBenchmark', args: { iterations: 100, rows: 480 } },
+  { name: 'keyed reorder (240 × 100)',       fn: '__benchKeyedReorder',         args: { iterations: 100, rows: 240 } },
+  { name: 'mount/unmount (200 × 100)',       fn: '__benchMountUnmount',         args: { iterations: 100, rows: 200 } },
+  { name: 'deep tree (depth 60 × 100)',      fn: '__benchDeepTree',             args: { iterations: 100, depth: 60 } },
+  { name: 'state churn (240 × 100)',         fn: '__benchStateChurn',           args: { iterations: 100, rows: 240 } },
+]
+
+const browser = await chromium.launch()
+const context = await browser.newContext()
+const page = await context.newPage()
+await page.goto(URL, { waitUntil: 'load' })
+await page.waitForFunction(`typeof window.${WORKLOADS[0].fn} === "function"`, { timeout: 30_000 })
+
+console.log(`url=${URL}  samples=${SAMPLES}\n`)
+console.log('workload'.padEnd(40), 'min'.padStart(7), 'median'.padStart(7), 'mean'.padStart(7))
+console.log('-'.repeat(40 + 1 + 7 + 1 + 7 + 1 + 7))
+
+for (const w of WORKLOADS) {
+  // Warmup
+  await page.evaluate(({ fn, args }) => window[fn]({ ...args, iterations: 20 }), { fn: w.fn, args: w.args })
+  const samples = []
+  for (let i = 0; i < SAMPLES; i += 1) {
+    const r = await page.evaluate(
+      ({ fn, args }) => window[fn](args),
+      { fn: w.fn, args: w.args },
+    )
+    samples.push(r.totalMs)
+  }
+  samples.sort((a, b) => a - b)
+  const min = samples[0]
+  const median = samples[Math.floor(samples.length / 2)]
+  const mean = samples.reduce((a, b) => a + b, 0) / samples.length
+  console.log(
+    w.name.padEnd(40),
+    `${min.toFixed(2)}`.padStart(7),
+    `${median.toFixed(2)}`.padStart(7),
+    `${mean.toFixed(2)}`.padStart(7),
+  )
+}
+
+await browser.close()

--- a/scripts/size-check.mjs
+++ b/scripts/size-check.mjs
@@ -26,10 +26,15 @@ const root = resolve(__dirname, '..')
 // portal→div swap on mobile→desktop.
 const BUDGETS = {
   'redact': 2780,
-  'redact/dom-client': 9460,
-  'redact/dom-client (nano)': 7090,
-  'redact/dom-client (suspense=stub)': 8800,
-  'redact/dom-client (hydration=stub)': 8160,
+  // dom-client + variants ~150 B above their earlier budgets to accommodate
+  // the stable-list reconciler fast path, renderHost single-pass diff,
+  // singleton dispatcher, and text-wrapper-elimination changes (PR #N).
+  // These collectively cut the canonical render bench by ~25 % and put
+  // redact ~20 % ahead of React on the same workload.
+  'redact/dom-client': 9650,
+  'redact/dom-client (nano)': 7270,
+  'redact/dom-client (suspense=stub)': 8980,
+  'redact/dom-client (hydration=stub)': 8330,
 }
 
 const alias = {


### PR DESCRIPTION
Follow-up to [#6](https://github.com/TanStack/redact/pull/6). After 0.0.9
shipped, re-profiled the canonical render bench in real Chrome and went
after the next layer of hotspots.

## Changes

* **`renderText` writes unconditionally** past the identity-fast-path.
  The `(fiber.dom as Text).data !== text` getter is redundant once the
  early-return catches the unchanged case (adoptTextDom already aligns
  `.data` to `text` on hydration).
* **Singleton dispatcher.** `makeDispatcher()` was allocating a fresh
  wrapper + 17 method closures per function-component render, with
  nothing render-local to capture. Hoisted to one instance — per-hook
  closures still live on the hook itself.
* **Text wrappers eliminated.** `NormalizedChild` is now
  `ReactElement | string | null` (was `… | {_text: string} | null`).
  Strings flow through the reconciler directly, no `_text` indirection.
  Cuts ~144 k allocations per 100-tick run; this was the GC source
  of the median variance still visible after #6. `typeof === 'string'`
  is also a strictly safer text predicate than `$$typeof === undefined`
  (RSC renderable proxies aren't strings, so the predicate can't be
  fooled by `has`-trap proxies that would defeat property-name checks).
* **Fast-path validation + commit merged into one pass** over
  `newChildren`. On any divergence we fall back to the slow path,
  which rebuilds the sibling chain anyway — partial pendingProps
  writes are idempotent.

Also adds a small **multi-workload bench harness**
(`scripts/multi-bench.mjs` + `examples/perf-bench/src/workloads.ts`) so
future perf changes can confirm they don't regress patterns the
canonical bench doesn't exercise (keyed reorder, mount/unmount, deep
trees, state churn).

## Bench (real Chrome, 30 samples, vs deployed React)

| state | redact min | redact median | ratio |
|---|---|---|---|
| 0.0.9 (baseline) | 50.9 ms | 55.2 ms | 1.00–1.07× slower |
| **0.0.10** | **37.3 ms** | **40.3 ms** | **0.82–0.84× FASTER** |

## Multi-workload (15 samples each, vs 0.0.9)

| workload | 0.0.9 median | 0.0.10 median | Δ |
|---|---|---|---|
| canonical 480×100 | 60 ms | 41 ms | **−32 %** |
| keyed reorder 240×100 | 19 ms | 17 ms | −9 % |
| mount/unmount 200×100 | 17 ms | 17 ms | neutral |
| deep tree depth 60 | 0.6 ms | 0.3 ms | −50 % |
| state churn 240×100 | 18 ms | 14 ms | **−22 %** |

Slow-path workloads stay neutral — confirming the changes target the
fast path without regressing anything else.

## Things tried and reverted

- `renderFiber` switch-dispatch over the four core tags — neutral or
  slightly worse. V8 was already optimizing the indirect call via
  inline caches.
- Precomputed-anchor reverse sweep in pass 2 — turned out to be a
  bigger version of #6's fix-1 mistake (the existing inner loop
  already breaks immediately on the first sibling with a DOM in
  steady state, so it's effectively O(N), not O(N²)).

## Size

`dom-client` variants grow ~150 B gzip; budgets bumped (~1.5 %).
Trade looks fine vs the perf gain.

Bumps to **0.0.10**.

## Test plan

- [x] `pnpm --filter tests test` — 722/722 pass
- [x] `pnpm test:types` — clean
- [x] `pnpm size:check` — under all (bumped) budgets
- [x] `pnpm bench` — 0.82–0.84× confirmed across multiple runs
- [x] `node scripts/multi-bench.mjs` — slow-path workloads neutral
- [ ] CI green
- [ ] Smoke-test against tannerlinsley.com after publish