### PR TITLE
Add React DOM edge server aliases

### DIFF
--- a/packages/redact/src/vite/index.ts
+++ b/packages/redact/src/vite/index.ts
@@ -166,6 +166,8 @@ const ALIASES: Record<string, string> = {
   'react/jsx-dev-runtime': '@tanstack/redact/jsx-dev-runtime',
   'react/compiler-runtime': '@tanstack/redact/compiler-runtime',
   'react-dom/client': '@tanstack/redact/dom-client',
+  'react-dom/server.edge': '@tanstack/redact/server',
+  'react-dom/static.edge': '@tanstack/redact/server',
   'react-dom/server': '@tanstack/redact/server',
   'react-dom/test-utils': '@tanstack/redact/dom-test-utils',
   'react-dom': '@tanstack/redact/dom',

--- a/tests/vite-plugin.test.ts
+++ b/tests/vite-plugin.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { resolve } from 'node:path'
+import { redact } from '@tanstack/redact/vite'
+
+describe('redact vite plugin', () => {
+  it('aliases React DOM edge server entrypoints', async () => {
+    const packageRoot = resolve(import.meta.dirname, '../packages/redact')
+    const plugin = redact({
+      packageRoots: {
+        '@tanstack/redact': packageRoot,
+      },
+    })
+
+    plugin.configResolved?.({
+      root: resolve(import.meta.dirname, '..'),
+      server: { fs: { allow: [] } },
+    } as any)
+
+    const context = { environment: { name: 'ssr' } }
+    await expect(plugin.resolveId.call(context, 'react-dom/server.edge')).resolves.toMatch(
+      /packages\/redact\/dist\/server\/index\.js$/,
+    )
+    await expect(plugin.resolveId.call(context, 'react-dom/static.edge')).resolves.toMatch(
+      /packages\/redact\/dist\/server\/index\.js$/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Alias `react-dom/server.edge` and `react-dom/static.edge` to `@tanstack/redact/server` in the Redact Vite plugin.
- Add a focused plugin test that resolves both edge entrypoints through a local package root.

## Why
vinext App Router builds run through Vite RSC and edge-oriented SSR entrypoints. Those generated bundles can import React DOM through `react-dom/server.edge` and `react-dom/static.edge`, while Redact previously only claimed `react-dom/server`. When swapping vinext client/SSR environments to Redact, these edge imports need to resolve to the same Redact server implementation instead of escaping to React DOM or failing resolution.

This keeps Redact's RSC rule intact: the plugin still skips the `rsc` environment so React Flight serialization continues to use real React internals, while client and SSR environments can use Redact.

## Validation
- `pnpm --filter tests test -- vite-plugin`