### PR TITLE
Support vinext SSR stream bootstrap

### DIFF
--- a/packages/redact/src/server/stream.ts
+++ b/packages/redact/src/server/stream.ts
@@ -8,10 +8,12 @@ import {
 } from './dispatcher'
 import { walk, type SuspendedBoundary } from './walk'
 import { BOUNDARY_REVEAL_RUNTIME, revealScript } from './bootstrap-script'
+import { escapeScript } from './escape'
 
 export interface StreamOptions {
   identifierPrefix?: string
   nonce?: string
+  bootstrapScriptContent?: string | ReadonlyArray<string>
   bootstrapScripts?: ReadonlyArray<string | { src: string; async?: boolean; nonce?: string }>
   bootstrapModules?: ReadonlyArray<string | { src: string; nonce?: string }>
   onError?: (error: unknown) => string | void
@@ -57,12 +59,34 @@ export async function streamHtml(
       shellChunks.push(chunk)
     }
 
-    // 1. Render the shell
-    walk(children, {
-      emit: bufferedEmit,
-      onSuspend: (b) => boundaries.push(b),
-      nextBoundaryId: () => state.nextId++,
-    })
+    // 1. Render the shell. A root-level `use(promise)` has no Suspense
+    // boundary to capture it, but App Router SSR commonly suspends at this
+    // level while resolving the RSC stream. Wait and retry without leaking
+    // partial shell chunks or boundary ids from the aborted attempt.
+    let shellRendered = false
+    let rootRetries = 0
+    while (!shellRendered) {
+      const chunkCount = shellChunks.length
+      const boundaryCount = boundaries.length
+      const nextId = state.nextId
+      try {
+        walk(children, {
+          emit: bufferedEmit,
+          onSuspend: (b) => boundaries.push(b),
+          nextBoundaryId: () => state.nextId++,
+        })
+        shellRendered = true
+      } catch (err) {
+        shellChunks.length = chunkCount
+        boundaries.length = boundaryCount
+        state.nextId = nextId
+        if (!isThenable(err)) throw err
+        if (++rootRetries > 50) {
+          throw new Error('renderToReadableStream exceeded 50 root suspension retries.')
+        }
+        await err
+      }
+    }
 
     // 2. Inject runtime + bootstrap scripts (once, after shell). Skip the
     // reveal/event-replay runtime when nothing needs it — no suspensions to
@@ -71,10 +95,14 @@ export async function streamHtml(
     // matches React's behavior where `renderToReadableStream` of a static
     // tree emits only the markup.
     const hasBootstrap =
+      bootstrapScriptContentToArray(options.bootstrapScriptContent).length > 0 ||
       (options.bootstrapScripts?.length ?? 0) > 0 ||
       (options.bootstrapModules?.length ?? 0) > 0
     if (boundaries.length > 0 || hasBootstrap) {
       shellChunks.push(`<script${nonce ? ` nonce="${nonce}"` : ''}>${BOUNDARY_REVEAL_RUNTIME}</script>`)
+      for (const content of bootstrapScriptContentToArray(options.bootstrapScriptContent)) {
+        shellChunks.push(inlineBootstrapTag(content, nonce))
+      }
       for (const s of options.bootstrapScripts ?? []) {
         shellChunks.push(bootstrapTag(s, 'script', nonce))
       }
@@ -83,7 +111,7 @@ export async function streamHtml(
       }
     }
 
-    if (shellChunks.length) emit(shellChunks.join(''))
+    if (shellChunks.length) emit(normalizeDocumentShell(shellChunks.join('')))
 
     // 3. Stream suspended boundaries as they resolve
     for (const b of boundaries) streamBoundary(b, emit, options, state)
@@ -144,6 +172,59 @@ async function drain(state: OrchestratorState): Promise<void> {
   while (state.pending.size > 0) {
     await Promise.race(state.pending)
   }
+}
+
+function isThenable(value: unknown): value is Promise<unknown> {
+  return !!value && typeof (value as { then?: unknown }).then === 'function'
+}
+
+function bootstrapScriptContentToArray(
+  content: StreamOptions['bootstrapScriptContent'],
+): string[] {
+  if (content === undefined) return []
+  return typeof content === 'string' ? [content] : [...content]
+}
+
+function inlineBootstrapTag(content: string, defaultNonce: string | undefined): string {
+  const nAttr = defaultNonce ? ` nonce="${defaultNonce}"` : ''
+  return `<script${nAttr}>${escapeScript(content)}</script>`
+}
+
+function normalizeDocumentShell(html: string): string {
+  const doctypeIndex = html.indexOf('<!DOCTYPE html><html')
+  if (doctypeIndex <= 0) return html
+
+  const headPrefix = html.slice(0, doctypeIndex)
+  if (!isHeadPrefix(headPrefix)) return html
+
+  const documentHtml = html.slice(doctypeIndex)
+  const headOpen = documentHtml.match(/<head(?:\s[^>]*)?>/)
+  if (!headOpen || headOpen.index === undefined) return html
+
+  const insertAt = headOpen.index + headOpen[0].length
+  return documentHtml.slice(0, insertAt) + headPrefix + documentHtml.slice(insertAt)
+}
+
+function isHeadPrefix(value: string): boolean {
+  if (!value) return false
+  return stripLeadingHeadTags(value).trim() === ''
+}
+
+function stripLeadingHeadTags(value: string): string {
+  let rest = value
+  let changed = true
+  while (changed) {
+    changed = false
+    const next = rest.replace(
+      /^\s*(?:<meta\b[^>]*>|<link\b[^>]*>|<base\b[^>]*>|<title\b[^>]*>[\s\S]*?<\/title>|<style\b[^>]*>[\s\S]*?<\/style>|<script\b[^>]*>[\s\S]*?<\/script>)/i,
+      '',
+    )
+    if (next !== rest) {
+      rest = next
+      changed = true
+    }
+  }
+  return rest
 }
 
 function bootstrapTag(

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -146,4 +146,47 @@ describe('renderToReadableStream', () => {
     expect(out).toContain('$RC(')
     await stream.allReady
   })
+
+  it('emits escaped inline bootstrap script content', async () => {
+    const stream = await renderToReadableStream(<div>hello</div>, {
+      bootstrapScriptContent: 'globalThis.started = "</script>"',
+    } as any)
+    const out = await streamToString(stream)
+    expect(out).toContain('<div>hello</div>')
+    expect(out).toContain('<script>globalThis.started = "<\\/script>"</script>')
+    await stream.allReady
+  })
+
+  it('retries when the root render suspends before any boundary', async () => {
+    let resolve!: (value: string) => void
+    const promise = new Promise<string>((r) => {
+      resolve = r
+    })
+    function App() {
+      return <main>{React.use(promise)}</main>
+    }
+
+    const stream = await renderToReadableStream(<App />)
+    resolve('ready')
+    const out = await streamToString(stream)
+    expect(out).toBe('<main>ready</main>')
+    await stream.allReady
+  })
+
+  it('moves leading head tags into an existing document head', async () => {
+    const stream = await renderToReadableStream(
+      <>
+        <meta name="viewport" content="width=device-width" />
+        <html>
+          <head></head>
+          <body>ok</body>
+        </html>
+      </>,
+    )
+    const out = await streamToString(stream)
+    expect(out).toBe(
+      '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width"/></head><body>ok</body></html>',
+    )
+    await stream.allReady
+  })
 })


### PR DESCRIPTION
## Summary
- Add `bootstrapScriptContent` support to the server stream options and emit escaped inline bootstrap scripts.
- Retry root-level thenable suspension during shell rendering, rolling back partial shell chunks, boundary records, and ids before awaiting and retrying.
- Normalize document shells where top-level head tags are emitted before `<!DOCTYPE html><html>`, moving those tags into the existing `<head>`.
- Add SSR tests for inline bootstrap content, root suspension retry, and document shell normalization.

## Why
vinext App Router SSR uses Vite RSC output. The browser entry is provided to the HTML renderer as inline bootstrap script content, matching React DOM's `bootstrapScriptContent` option. Without this, the server HTML can render but the vinext client runtime does not start.

The same flow can suspend at the root while the RSC stream is resolved. In React, this is allowed; in Redact, the root throw escaped because there is no Suspense boundary above it. vinext needs Redact to await and retry the shell without leaking the aborted render's partial chunks.

The document-shell normalization covers React 19-style metadata projection that vinext/Next-compatible app trees can produce, where head tags may appear before the document root in the render tree but must land inside `<head>` in HTML.

## Validation
- `pnpm --filter tests test -- ssr`