### PR TITLE
Project document head elements

### DIFF
--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -147,6 +147,8 @@ const HEAD_KEY_ATTRS: Record<string, ReadonlyArray<string>> = {
   title: [],
 }
 
+const DOCUMENT_HEAD_TAGS = new Set(['base', 'link', 'meta', 'script', 'style', 'title'])
+
 // DOM elements already claimed by some fiber during this hydration pass.
 const CLAIMED = new WeakSet<Node>()
 
@@ -246,13 +248,23 @@ export function adoptHostDom(fiber: Fiber, parent: Fiber): boolean {
   if (!cursor) return false
 
   const tag = (fiber.type as string).toLowerCase()
+  const documentHeadParent = getDocumentHeadParent(cursor.parent, tag)
   const parentEl = cursor.parent as Element
   const parentTag =
     parentEl.nodeType === 1 ? (parentEl as Element).tagName.toLowerCase() : ''
-  const isHeadish = parentTag === 'head' || parentTag === 'html'
+  const isHeadish = parentTag === 'head' || parentTag === 'html' || !!documentHeadParent
 
   let candidate: ChildNode | null
-  if (isHeadish) {
+  if (documentHeadParent) {
+    // React 19 can project <meta>/<title>/<link> from anywhere in the tree into
+    // document.head. Redact does not have that projection yet, so when a
+    // document-root hydration pass sees a top-level head element, adopt it
+    // from <head> rather than trying to append it beside <html>.
+    candidate = new HydrationCursor(documentHeadParent).takeMatchingHeadElement(
+      tag,
+      fiber.pendingProps ?? {},
+    )
+  } else if (isHeadish) {
     // Head/html children are position-insensitive — server may emit them in
     // a different order than the React tree (React 19 head hoisting, etc.).
     // Scan forward without removing non-matching nodes; match on attribute
@@ -295,6 +307,11 @@ export function adoptHostDom(fiber: Fiber, parent: Fiber): boolean {
   // Set up child cursor for this host's children
   hydrationCursors.set(fiber, new HydrationCursor(candidate))
   return true
+}
+
+function getDocumentHeadParent(parent: Node, tag: string): HTMLHeadElement | null {
+  if (parent.nodeType !== 9 || !DOCUMENT_HEAD_TAGS.has(tag)) return null
+  return (parent as Document).head
 }
 
 export function adoptTextDom(fiber: Fiber, parent: Fiber, text: string): boolean {

--- a/packages/redact/src/dom/reconcile.ts
+++ b/packages/redact/src/dom/reconcile.ts
@@ -1074,6 +1074,12 @@ export function unmountAllChildren(parent: Fiber, domParent: Node): void {
 // ---------------------------------------------------------------------------
 
 function insertInto(parent: Node, node: Node, anchor: Node | null): void {
+  const projectedHeadParent = getDocumentHeadInsertionParent(parent, node)
+  if (projectedHeadParent) {
+    projectedHeadParent.appendChild(node)
+    return
+  }
+
   // Anchor may have been removed or moved since it was computed (mutations
   // from unmount, boundary reveal, user code, HMR). If it's no longer a child
   // of `parent`, fall back to append — trying to insertBefore a non-child
@@ -1083,6 +1089,15 @@ function insertInto(parent: Node, node: Node, anchor: Node | null): void {
   } else {
     parent.appendChild(node)
   }
+}
+
+const DOCUMENT_HEAD_TAGS = new Set(['base', 'link', 'meta', 'script', 'style', 'title'])
+
+function getDocumentHeadInsertionParent(parent: Node, node: Node): HTMLHeadElement | null {
+  if (parent.nodeType !== 9 || node.nodeType !== 1) return null
+  const tag = (node as Element).tagName.toLowerCase()
+  if (!DOCUMENT_HEAD_TAGS.has(tag)) return null
+  return (parent as Document).head
 }
 
 function getHostParent(fiber: Fiber): Node {
@@ -1260,4 +1275,3 @@ function isEventProp(name: string): boolean {
     name.charCodeAt(2) >= 65 /* 'A'-ish: any uppercase start (onClick, onChange, …) */
   )
 }
-

--- a/packages/redact/src/dom/root.ts
+++ b/packages/redact/src/dom/root.ts
@@ -1,4 +1,11 @@
-import { FiberTag, createFiber, type FiberRoot, type ReactNode } from '../core'
+import {
+  FiberTag,
+  REACT_ELEMENT_TYPE,
+  createFiber,
+  type FiberRoot,
+  type ReactElement,
+  type ReactNode,
+} from '../core'
 import { renderRoot, flushSyncWork, batchedUpdates } from './reconcile'
 import {
   beginHydration,
@@ -92,8 +99,10 @@ export function hydrateRoot(
 
   beginHydration(root)
   try {
+    const normalizedInitialChildren =
+      isDocumentContainer(container) ? normalizeDocumentChildren(initialChildren) : initialChildren
     flushSyncWork(() => {
-      renderRoot(root, initialChildren)
+      renderRoot(root, normalizedInitialChildren)
     })
   } finally {
     endHydration(root)
@@ -103,7 +112,7 @@ export function hydrateRoot(
   return {
     render(children) {
       flushSyncWork(() => {
-        renderRoot(root, children)
+        renderRoot(root, isDocumentContainer(container) ? normalizeDocumentChildren(children) : children)
       })
     },
     unmount() {
@@ -111,6 +120,93 @@ export function hydrateRoot(
         renderRoot(root, null)
       })
     },
+  }
+}
+
+const HEAD_TAGS = new Set(['base', 'link', 'meta', 'script', 'style', 'title'])
+
+function isDocumentContainer(container: unknown): container is Document {
+  return !!container && (container as Node).nodeType === 9
+}
+
+function normalizeDocumentChildren(children: ReactNode): ReactNode {
+  const list = toChildArray(children)
+  const htmlIndex = list.findIndex((child) => isHostElement(child, 'html'))
+  if (htmlIndex === -1) return children
+
+  const headNodes = list.filter(isHeadElement)
+  if (headNodes.length === 0) return children
+
+  const htmlElement = list[htmlIndex] as ReactElement
+  const normalizedHtml = hoistIntoHtmlHead(htmlElement, headNodes)
+  return list
+    .filter((child, index) => index === htmlIndex || !isHeadElement(child))
+    .map((child) => (child === htmlElement ? normalizedHtml : child))
+}
+
+function hoistIntoHtmlHead(htmlElement: ReactElement, headNodes: ReactNode[]): ReactElement {
+  const htmlChildren = toChildArray(htmlElement.props?.children)
+  const headIndex = htmlChildren.findIndex((child) => isHostElement(child, 'head'))
+  let nextChildren: ReactNode[]
+
+  if (headIndex === -1) {
+    nextChildren = [
+      createHostElement('head', { children: headNodes }),
+      ...htmlChildren,
+    ]
+  } else {
+    const headElement = htmlChildren[headIndex] as ReactElement
+    const existingHeadChildren = toChildArray(headElement.props?.children)
+    const nextHead = {
+      ...headElement,
+      props: {
+        ...headElement.props,
+        children: [...headNodes, ...existingHeadChildren],
+      },
+    }
+    nextChildren = htmlChildren.map((child, index) => (index === headIndex ? nextHead : child))
+  }
+
+  return {
+    ...htmlElement,
+    props: {
+      ...htmlElement.props,
+      children: nextChildren,
+    },
+  }
+}
+
+function toChildArray(children: unknown): ReactNode[] {
+  if (children == null || typeof children === 'boolean') return []
+  if (Array.isArray(children)) return children as ReactNode[]
+  if (isReactElement(children)) return [children]
+  if (typeof children !== 'string' && isIterable(children)) return Array.from(children) as ReactNode[]
+  return [children as ReactNode]
+}
+
+function isHeadElement(value: ReactNode): boolean {
+  return isReactElement(value) && typeof value.type === 'string' && HEAD_TAGS.has(value.type)
+}
+
+function isHostElement(value: ReactNode, tag: string): boolean {
+  return isReactElement(value) && value.type === tag
+}
+
+function isReactElement(value: unknown): value is ReactElement {
+  return !!value && typeof value === 'object' && (value as ReactElement).$$typeof === REACT_ELEMENT_TYPE
+}
+
+function isIterable(value: unknown): value is Iterable<ReactNode> {
+  return !!value && typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function'
+}
+
+function createHostElement(type: string, props: Record<string, unknown>): ReactElement {
+  return {
+    $$typeof: REACT_ELEMENT_TYPE,
+    type,
+    key: null,
+    ref: null,
+    props,
   }
 }
 

--- a/packages/redact/src/server/walk.ts
+++ b/packages/redact/src/server/walk.ts
@@ -315,6 +315,10 @@ function walkHost(
   const parentTextState = opts.textState
   const childOpts: WalkOptions = { ...opts, textState: { lastWasText: false } }
 
+  if (tag === 'html' && !hasHeadChild(props.children)) {
+    opts.emit('<head></head>')
+  }
+
   const dangerouslyHtml = props.dangerouslySetInnerHTML?.__html
 
   if (isTextarea && textareaValue != null) {
@@ -351,6 +355,32 @@ function walkHost(
   if (isSelect) popSelectContext()
   // Host element closing resets outer flow — next sibling text starts fresh.
   if (parentTextState) parentTextState.lastWasText = false
+}
+
+function hasHeadChild(children: unknown): boolean {
+  if (children == null || typeof children === 'boolean') return false
+  if (Array.isArray(children)) return children.some(hasHeadChild)
+  if (typeof children !== 'string' && isIterable(children)) {
+    for (const child of children as Iterable<unknown>) {
+      if (hasHeadChild(child)) return true
+    }
+    return false
+  }
+  return isElementOfType(children, 'head')
+}
+
+function isElementOfType(value: unknown, type: string): value is ReactElement {
+  const marker = (value as ReactElement | null)?.$$typeof as unknown
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (marker === REACT_ELEMENT_TYPE || marker === REACT_LEGACY_ELEMENT_TYPE) &&
+    (value as ReactElement).type === type
+  )
+}
+
+function isIterable(value: unknown): value is Iterable<unknown> {
+  return !!value && typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function'
 }
 
 function walkComponent(

--- a/tests/document-hydration.test.tsx
+++ b/tests/document-hydration.test.tsx
@@ -37,6 +37,53 @@ describe('hydrateRoot(document, <html/>)', () => {
     expect(doc.documentElement.querySelector('h1')?.textContent).toBe('hi')
   })
 
+  it('server-renders a head when an html tree omits it', () => {
+    function App() {
+      return (
+        <html>
+          <body>
+            <h1>hi</h1>
+          </body>
+        </html>
+      )
+    }
+
+    expect(renderToString(<App />)).toBe(
+      '<!DOCTYPE html><html><head></head><body><h1>hi</h1></body></html>',
+    )
+  })
+
+  it('hydrates React 19-style top-level head tags from document.head', () => {
+    function App() {
+      return (
+        <>
+          <meta name="viewport" content="width=device-width" />
+          <html>
+            <body>
+              <h1>hi</h1>
+            </body>
+          </html>
+        </>
+      )
+    }
+
+    const doc = buildDocumentFrom(
+      '<!doctype html><html><head><meta name="viewport" content="width=device-width"></head><body><h1>hi</h1></body></html>',
+    )
+    const origHtml = doc.documentElement
+    const errors: unknown[] = []
+
+    hydrateRoot(doc as any, <App />, {
+      onRecoverableError: (e) => errors.push(e),
+      onUncaughtError: (e) => errors.push(e),
+    })
+
+    expect(doc.documentElement).toBe(origHtml)
+    expect(doc.head.querySelectorAll('meta[name="viewport"]').length).toBe(1)
+    expect(doc.documentElement.querySelector('h1')?.textContent).toBe('hi')
+    expect(errors).toEqual([])
+  })
+
   it('a root-level component suspending during hydration does not append a second <html>', async () => {
     // Mirrors Start's <StartClient/> → <Await promise={...}> pattern: the
     // root-most component throws a promise synchronously during hydrateRoot.


### PR DESCRIPTION
## Summary
- Ensure SSR emits an empty `<head>` when rendering an `<html>` tree with no head child.
- Hoist top-level React 19-style head tags into `<head>` when hydrating a Document root.
- Adopt document-level head tags from `document.head` during hydration and insert new document-level head tags into `document.head`.
- Add document hydration coverage for omitted `<head>` and top-level metadata.

## Why
vinext follows Next/App Router document semantics where metadata can be represented as top-level head elements around the html shell. Browsers only allow one document element and head-managed tags must live in `document.head`. Without this, Redact can try to append `<meta>` directly to `document` during hydration, causing `Only one element on document allowed`, or fail to match server-rendered metadata.

This makes Redact compatible with vinext App Router SSR/hydration while keeping existing `<head>`/`<html>` adoption position-insensitive.

## Validation
- `pnpm --filter tests test -- document-hydration`