### PR TITLE
Expose ReactDOM Flight hint internals

### DIFF
--- a/packages/redact/src/dom/index.ts
+++ b/packages/redact/src/dom/index.ts
@@ -14,6 +14,22 @@ export function preinit(_href: string, _opts?: any): void {}
 export function preloadModule(_href: string, _opts?: any): void {}
 export function preinitModule(_href: string, _opts?: any): void {}
 
+export const __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = {
+  d: {
+    f() {},
+    r() {},
+    D() {},
+    C() {},
+    L() {},
+    m() {},
+    X() {},
+    S() {},
+    M() {},
+  },
+  p: 0,
+  findDOMNode: null,
+}
+
 export const version = '19.2.3'
 
 // Required by React's default export consumers
@@ -29,5 +45,6 @@ export default {
   preinit,
   preloadModule,
   preinitModule,
+  __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
   version: '19.2.3',
 }

--- a/tests/public-exports.test.ts
+++ b/tests/public-exports.test.ts
@@ -109,6 +109,7 @@ describe('public API surface', () => {
   it('@tanstack/redact/dom', () => {
     expect(surface(redactDom)).toMatchInlineSnapshot(`
       [
+        "__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE",
         "createPortal",
         "default",
         "flushSync",


### PR DESCRIPTION
## Summary
- Add the ReactDOM internal object expected by `react-server-dom-webpack/client.edge`.
- Provide no-op resource hint handlers for Flight hint rows (`H` rows) plus the `findDOMNode`/priority shape React expects.
- Cover the new public DOM export in the export snapshot test.

## Why
vinext uses the RSC client decoder from `react-server-dom-webpack/client.edge`. That decoder reads `ReactDOM.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE.d` when it processes Flight hint rows for preload/preinit/resource hints. Without that object, a vinext app can successfully receive SSR HTML from Redact but then crash while decoding the Flight stream on the client.

The handlers are no-ops for now because these hints are opportunistic resource hints, and vinext also injects modulepreload links through its Vite/RSC pipeline. This gives Redact the compatibility shape needed for vinext demos without taking on a larger resource scheduling implementation yet.

## Validation
- `pnpm --filter tests test -- public-exports`