### PR TITLE
chore(redact/hydration): rename internal '__tdom*' scroll-guard globals to '__redact*'

### DIFF
--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -21,18 +21,18 @@ const GUARD_WINDOW_MS = 3000
 export function installHydrationScrollGuard(): void {
   if (typeof window === 'undefined') return
   const w = window as any
-  if (w.__tdomScrollGuardInstalled) return
-  w.__tdomScrollGuardInstalled = true
+  if (w.__redactScrollGuardInstalled) return
+  w.__redactScrollGuardInstalled = true
   const guardStartedAt = performance.now()
   let lastUserScrollAt = 0
   let programmatic = 0
-  w.__tdomScrollLog = []
+  w.__redactScrollLog = []
   window.addEventListener(
     'scroll',
     () => {
       if (programmatic === 0) {
         lastUserScrollAt = performance.now()
-        w.__tdomScrollLog.push({ t: Math.round(lastUserScrollAt), ev: 'user-scroll', y: window.scrollY })
+        w.__redactScrollLog.push({ t: Math.round(lastUserScrollAt), ev: 'user-scroll', y: window.scrollY })
       }
     },
     { capture: true, passive: true },
@@ -43,7 +43,7 @@ export function installHydrationScrollGuard(): void {
     const inGuardWindow = now - guardStartedAt < GUARD_WINDOW_MS
     const userScrolledRecently = lastUserScrollAt > 0 && now - lastUserScrollAt < 1500
     if (inGuardWindow && userScrolledRecently) {
-      w.__tdomScrollLog.push({
+      w.__redactScrollLog.push({
         t: Math.round(now),
         ev: 'suppressed',
         args: JSON.stringify(args).slice(0, 80),
@@ -52,7 +52,7 @@ export function installHydrationScrollGuard(): void {
       })
       return
     }
-    w.__tdomScrollLog.push({
+    w.__redactScrollLog.push({
       t: Math.round(now),
       ev: 'allowed',
       args: JSON.stringify(args).slice(0, 80),


### PR DESCRIPTION
## Summary

- **Rename leftover debug globals**: `__tdomScrollGuardInstalled` → `__redactScrollGuardInstalled`, `__tdomScrollLog` → `__redactScrollLog`, used only by `installHydrationScrollGuard()` in `dom/features/hydration/full.ts`.
- **Cleanup miss from the `@tanstack/redact` consolidation in #2**: other internal identifiers (notably `Symbol.for('@tanstack/redact.ReactSharedInternals')`) already use the new prefix — these two `window.__*` debug globals were missed.
- **Not part of any contract**: typed via `(window as any)`, no consumer references in source/tests/examples, stub variant doesn't reference them. Pure rename, behavior unchanged.

## Test plan

- [x] `pnpm test` — 727/727 pass
- [x] `pnpm test:types` — clean
- [x] grep `ScrollGuardInstalled|ScrollLog` repo-wide — only the 6 sites updated in this PR