### PR TITLE
docs(redact/server): correct fallback wire-format comment — fallback '<div>' is visible, not hidden

### DIFF
--- a/packages/redact/src/server/bootstrap-script.ts
+++ b/packages/redact/src/server/bootstrap-script.ts
@@ -6,9 +6,12 @@
  *     main bundle can replay them against un-hydrated subtrees ($RE_q buffer).
  *
  * Wire format:
- *   Fallback:  <!--$?ID--><div hidden id="B:ID">fallback</div><!--/$-->
+ *   Fallback:  <!--$?ID--><div id="B:ID">fallback</div><!--/$-->
  *   Resolved:  emits <div hidden id="S:ID">real</div><script>$RC(ID)</script>
  *              which splices real into place and rewrites the comment to <!--$ID-->.
+ *              The fallback div is visible (it's the user-visible loading
+ *              state); only the resolved-content staging div is `hidden`
+ *              before $RC moves its children inline.
  *
  * Client hydration calls $RH(ID, cb) to register a callback invoked once the
  * boundary has been revealed (or immediately, if it was already revealed).


### PR DESCRIPTION
## Summary

- **Comment vs. emit drift**: `bootstrap-script.ts`'s wire-format block comment claimed `<!--$?ID--><div hidden id="B:ID">fallback</div><!--/$-->`, but the actual emit at `walk.ts:441` writes `<div id="B:ID">` (no `hidden`). The adjacent comment at `walk.ts:438` already states "Visible div wrapper so the fallback UI shows".
- **Why visible is correct**: the `B:` div wraps the user-visible loading state. Hiding it would defeat the purpose of streaming SSR fallbacks. Only the `S:` resolved-content staging div is `hidden`, so `$RC(ID)` can splice its children into place before the `B:` div is removed.
- **Doc-only**: comment text only; no behavior change.

## Test plan

- [x] grep `<div .* id="B:` repo-wide — only `walk.ts:441` emits, and it has no `hidden`
- [x] cross-checked against the runtime: `$RC` (`bootstrap-script.ts:30-39`) and `hydrateSuspenseBoundary` (`suspense/full.ts:141-148`) both assume a visible `B:` container
- [x] `pnpm test:types` — clean