### PR TITLE
feat(redact): vinext SSR/hydration compatibility — 0.0.9

### DIFF
--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/redact",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "React, redacted. A minimal React-API-compatible drop-in replacement.",
   "type": "module",
   "main": "./dist/react/index.js",

--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -147,6 +147,8 @@ const HEAD_KEY_ATTRS: Record<string, ReadonlyArray<string>> = {
   title: [],
 }
 
+const DOCUMENT_HEAD_TAGS = new Set(['base', 'link', 'meta', 'script', 'style', 'title'])
+
 // DOM elements already claimed by some fiber during this hydration pass.
 const CLAIMED = new WeakSet<Node>()
 
@@ -246,13 +248,23 @@ export function adoptHostDom(fiber: Fiber, parent: Fiber): boolean {
   if (!cursor) return false
 
   const tag = (fiber.type as string).toLowerCase()
+  const documentHeadParent = getDocumentHeadParent(cursor.parent, tag)
   const parentEl = cursor.parent as Element
   const parentTag =
     parentEl.nodeType === 1 ? (parentEl as Element).tagName.toLowerCase() : ''
-  const isHeadish = parentTag === 'head' || parentTag === 'html'
+  const isHeadish = parentTag === 'head' || parentTag === 'html' || !!documentHeadParent
 
   let candidate: ChildNode | null
-  if (isHeadish) {
+  if (documentHeadParent) {
+    // React 19 can project <meta>/<title>/<link> from anywhere in the tree into
+    // document.head. Redact does not have that projection yet, so when a
+    // document-root hydration pass sees a top-level head element, adopt it
+    // from <head> rather than trying to append it beside <html>.
+    candidate = new HydrationCursor(documentHeadParent).takeMatchingHeadElement(
+      tag,
+      fiber.pendingProps ?? {},
+    )
+  } else if (isHeadish) {
     // Head/html children are position-insensitive — server may emit them in
     // a different order than the React tree (React 19 head hoisting, etc.).
     // Scan forward without removing non-matching nodes; match on attribute
@@ -295,6 +307,11 @@ export function adoptHostDom(fiber: Fiber, parent: Fiber): boolean {
   // Set up child cursor for this host's children
   hydrationCursors.set(fiber, new HydrationCursor(candidate))
   return true
+}
+
+function getDocumentHeadParent(parent: Node, tag: string): HTMLHeadElement | null {
+  if (parent.nodeType !== 9 || !DOCUMENT_HEAD_TAGS.has(tag)) return null
+  return (parent as Document).head
 }
 
 export function adoptTextDom(fiber: Fiber, parent: Fiber, text: string): boolean {

--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -21,18 +21,18 @@ const GUARD_WINDOW_MS = 3000
 export function installHydrationScrollGuard(): void {
   if (typeof window === 'undefined') return
   const w = window as any
-  if (w.__tdomScrollGuardInstalled) return
-  w.__tdomScrollGuardInstalled = true
+  if (w.__redactScrollGuardInstalled) return
+  w.__redactScrollGuardInstalled = true
   const guardStartedAt = performance.now()
   let lastUserScrollAt = 0
   let programmatic = 0
-  w.__tdomScrollLog = []
+  w.__redactScrollLog = []
   window.addEventListener(
     'scroll',
     () => {
       if (programmatic === 0) {
         lastUserScrollAt = performance.now()
-        w.__tdomScrollLog.push({ t: Math.round(lastUserScrollAt), ev: 'user-scroll', y: window.scrollY })
+        w.__redactScrollLog.push({ t: Math.round(lastUserScrollAt), ev: 'user-scroll', y: window.scrollY })
       }
     },
     { capture: true, passive: true },
@@ -43,7 +43,7 @@ export function installHydrationScrollGuard(): void {
     const inGuardWindow = now - guardStartedAt < GUARD_WINDOW_MS
     const userScrolledRecently = lastUserScrollAt > 0 && now - lastUserScrollAt < 1500
     if (inGuardWindow && userScrolledRecently) {
-      w.__tdomScrollLog.push({
+      w.__redactScrollLog.push({
         t: Math.round(now),
         ev: 'suppressed',
         args: JSON.stringify(args).slice(0, 80),
@@ -52,7 +52,7 @@ export function installHydrationScrollGuard(): void {
       })
       return
     }
-    w.__tdomScrollLog.push({
+    w.__redactScrollLog.push({
       t: Math.round(now),
       ev: 'allowed',
       args: JSON.stringify(args).slice(0, 80),

--- a/packages/redact/src/dom/index.ts
+++ b/packages/redact/src/dom/index.ts
@@ -14,6 +14,22 @@ export function preinit(_href: string, _opts?: any): void {}
 export function preloadModule(_href: string, _opts?: any): void {}
 export function preinitModule(_href: string, _opts?: any): void {}
 
+export const __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = {
+  d: {
+    f() {},
+    r() {},
+    D() {},
+    C() {},
+    L() {},
+    m() {},
+    X() {},
+    S() {},
+    M() {},
+  },
+  p: 0,
+  findDOMNode: null,
+}
+
 export const version = '19.2.3'
 
 // Required by React's default export consumers
@@ -29,5 +45,6 @@ export default {
   preinit,
   preloadModule,
   preinitModule,
+  __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
   version: '19.2.3',
 }

--- a/packages/redact/src/dom/reconcile.ts
+++ b/packages/redact/src/dom/reconcile.ts
@@ -1074,6 +1074,12 @@ export function unmountAllChildren(parent: Fiber, domParent: Node): void {
 // ---------------------------------------------------------------------------
 
 function insertInto(parent: Node, node: Node, anchor: Node | null): void {
+  const projectedHeadParent = getDocumentHeadInsertionParent(parent, node)
+  if (projectedHeadParent) {
+    projectedHeadParent.appendChild(node)
+    return
+  }
+
   // Anchor may have been removed or moved since it was computed (mutations
   // from unmount, boundary reveal, user code, HMR). If it's no longer a child
   // of `parent`, fall back to append — trying to insertBefore a non-child
@@ -1083,6 +1089,15 @@ function insertInto(parent: Node, node: Node, anchor: Node | null): void {
   } else {
     parent.appendChild(node)
   }
+}
+
+const DOCUMENT_HEAD_TAGS = new Set(['base', 'link', 'meta', 'script', 'style', 'title'])
+
+function getDocumentHeadInsertionParent(parent: Node, node: Node): HTMLHeadElement | null {
+  if (parent.nodeType !== 9 || node.nodeType !== 1) return null
+  const tag = (node as Element).tagName.toLowerCase()
+  if (!DOCUMENT_HEAD_TAGS.has(tag)) return null
+  return (parent as Document).head
 }
 
 function getHostParent(fiber: Fiber): Node {
@@ -1260,4 +1275,3 @@ function isEventProp(name: string): boolean {
     name.charCodeAt(2) >= 65 /* 'A'-ish: any uppercase start (onClick, onChange, …) */
   )
 }
-

--- a/packages/redact/src/dom/root.ts
+++ b/packages/redact/src/dom/root.ts
@@ -1,4 +1,11 @@
-import { FiberTag, createFiber, type FiberRoot, type ReactNode } from '../core'
+import {
+  FiberTag,
+  REACT_ELEMENT_TYPE,
+  createFiber,
+  type FiberRoot,
+  type ReactElement,
+  type ReactNode,
+} from '../core'
 import { renderRoot, flushSyncWork, batchedUpdates } from './reconcile'
 import {
   beginHydration,
@@ -92,8 +99,10 @@ export function hydrateRoot(
 
   beginHydration(root)
   try {
+    const normalizedInitialChildren =
+      isDocumentContainer(container) ? normalizeDocumentChildren(initialChildren) : initialChildren
     flushSyncWork(() => {
-      renderRoot(root, initialChildren)
+      renderRoot(root, normalizedInitialChildren)
     })
   } finally {
     endHydration(root)
@@ -103,7 +112,7 @@ export function hydrateRoot(
   return {
     render(children) {
       flushSyncWork(() => {
-        renderRoot(root, children)
+        renderRoot(root, isDocumentContainer(container) ? normalizeDocumentChildren(children) : children)
       })
     },
     unmount() {
@@ -111,6 +120,93 @@ export function hydrateRoot(
         renderRoot(root, null)
       })
     },
+  }
+}
+
+const HEAD_TAGS = new Set(['base', 'link', 'meta', 'script', 'style', 'title'])
+
+function isDocumentContainer(container: unknown): container is Document {
+  return !!container && (container as Node).nodeType === 9
+}
+
+function normalizeDocumentChildren(children: ReactNode): ReactNode {
+  const list = toChildArray(children)
+  const htmlIndex = list.findIndex((child) => isHostElement(child, 'html'))
+  if (htmlIndex === -1) return children
+
+  const headNodes = list.filter(isHeadElement)
+  if (headNodes.length === 0) return children
+
+  const htmlElement = list[htmlIndex] as ReactElement
+  const normalizedHtml = hoistIntoHtmlHead(htmlElement, headNodes)
+  return list
+    .filter((child, index) => index === htmlIndex || !isHeadElement(child))
+    .map((child) => (child === htmlElement ? normalizedHtml : child))
+}
+
+function hoistIntoHtmlHead(htmlElement: ReactElement, headNodes: ReactNode[]): ReactElement {
+  const htmlChildren = toChildArray(htmlElement.props?.children)
+  const headIndex = htmlChildren.findIndex((child) => isHostElement(child, 'head'))
+  let nextChildren: ReactNode[]
+
+  if (headIndex === -1) {
+    nextChildren = [
+      createHostElement('head', { children: headNodes }),
+      ...htmlChildren,
+    ]
+  } else {
+    const headElement = htmlChildren[headIndex] as ReactElement
+    const existingHeadChildren = toChildArray(headElement.props?.children)
+    const nextHead = {
+      ...headElement,
+      props: {
+        ...headElement.props,
+        children: [...headNodes, ...existingHeadChildren],
+      },
+    }
+    nextChildren = htmlChildren.map((child, index) => (index === headIndex ? nextHead : child))
+  }
+
+  return {
+    ...htmlElement,
+    props: {
+      ...htmlElement.props,
+      children: nextChildren,
+    },
+  }
+}
+
+function toChildArray(children: unknown): ReactNode[] {
+  if (children == null || typeof children === 'boolean') return []
+  if (Array.isArray(children)) return children as ReactNode[]
+  if (isReactElement(children)) return [children]
+  if (typeof children !== 'string' && isIterable(children)) return Array.from(children) as ReactNode[]
+  return [children as ReactNode]
+}
+
+function isHeadElement(value: ReactNode): boolean {
+  return isReactElement(value) && typeof value.type === 'string' && HEAD_TAGS.has(value.type)
+}
+
+function isHostElement(value: ReactNode, tag: string): boolean {
+  return isReactElement(value) && value.type === tag
+}
+
+function isReactElement(value: unknown): value is ReactElement {
+  return !!value && typeof value === 'object' && (value as ReactElement).$$typeof === REACT_ELEMENT_TYPE
+}
+
+function isIterable(value: unknown): value is Iterable<ReactNode> {
+  return !!value && typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function'
+}
+
+function createHostElement(type: string, props: Record<string, unknown>): ReactElement {
+  return {
+    $$typeof: REACT_ELEMENT_TYPE,
+    type,
+    key: null,
+    ref: null,
+    props,
   }
 }
 

--- a/packages/redact/src/server/bootstrap-script.ts
+++ b/packages/redact/src/server/bootstrap-script.ts
@@ -6,9 +6,12 @@
  *     main bundle can replay them against un-hydrated subtrees ($RE_q buffer).
  *
  * Wire format:
- *   Fallback:  <!--$?ID--><div hidden id="B:ID">fallback</div><!--/$-->
+ *   Fallback:  <!--$?ID--><div id="B:ID">fallback</div><!--/$-->
  *   Resolved:  emits <div hidden id="S:ID">real</div><script>$RC(ID)</script>
  *              which splices real into place and rewrites the comment to <!--$ID-->.
+ *              The fallback div is visible (it's the user-visible loading
+ *              state); only the resolved-content staging div is `hidden`
+ *              before $RC moves its children inline.
  *
  * Client hydration calls $RH(ID, cb) to register a callback invoked once the
  * boundary has been revealed (or immediately, if it was already revealed).

--- a/packages/redact/src/server/stream.ts
+++ b/packages/redact/src/server/stream.ts
@@ -8,10 +8,12 @@ import {
 } from './dispatcher'
 import { walk, type SuspendedBoundary } from './walk'
 import { BOUNDARY_REVEAL_RUNTIME, revealScript } from './bootstrap-script'
+import { escapeScript } from './escape'
 
 export interface StreamOptions {
   identifierPrefix?: string
   nonce?: string
+  bootstrapScriptContent?: string | ReadonlyArray<string>
   bootstrapScripts?: ReadonlyArray<string | { src: string; async?: boolean; nonce?: string }>
   bootstrapModules?: ReadonlyArray<string | { src: string; nonce?: string }>
   onError?: (error: unknown) => string | void
@@ -57,12 +59,34 @@ export async function streamHtml(
       shellChunks.push(chunk)
     }
 
-    // 1. Render the shell
-    walk(children, {
-      emit: bufferedEmit,
-      onSuspend: (b) => boundaries.push(b),
-      nextBoundaryId: () => state.nextId++,
-    })
+    // 1. Render the shell. A root-level `use(promise)` has no Suspense
+    // boundary to capture it, but App Router SSR commonly suspends at this
+    // level while resolving the RSC stream. Wait and retry without leaking
+    // partial shell chunks or boundary ids from the aborted attempt.
+    let shellRendered = false
+    let rootRetries = 0
+    while (!shellRendered) {
+      const chunkCount = shellChunks.length
+      const boundaryCount = boundaries.length
+      const nextId = state.nextId
+      try {
+        walk(children, {
+          emit: bufferedEmit,
+          onSuspend: (b) => boundaries.push(b),
+          nextBoundaryId: () => state.nextId++,
+        })
+        shellRendered = true
+      } catch (err) {
+        shellChunks.length = chunkCount
+        boundaries.length = boundaryCount
+        state.nextId = nextId
+        if (!isThenable(err)) throw err
+        if (++rootRetries > 50) {
+          throw new Error('renderToReadableStream exceeded 50 root suspension retries.')
+        }
+        await err
+      }
+    }
 
     // 2. Inject runtime + bootstrap scripts (once, after shell). Skip the
     // reveal/event-replay runtime when nothing needs it — no suspensions to
@@ -71,10 +95,14 @@ export async function streamHtml(
     // matches React's behavior where `renderToReadableStream` of a static
     // tree emits only the markup.
     const hasBootstrap =
+      bootstrapScriptContentToArray(options.bootstrapScriptContent).length > 0 ||
       (options.bootstrapScripts?.length ?? 0) > 0 ||
       (options.bootstrapModules?.length ?? 0) > 0
     if (boundaries.length > 0 || hasBootstrap) {
       shellChunks.push(`<script${nonce ? ` nonce="${nonce}"` : ''}>${BOUNDARY_REVEAL_RUNTIME}</script>`)
+      for (const content of bootstrapScriptContentToArray(options.bootstrapScriptContent)) {
+        shellChunks.push(inlineBootstrapTag(content, nonce))
+      }
       for (const s of options.bootstrapScripts ?? []) {
         shellChunks.push(bootstrapTag(s, 'script', nonce))
       }
@@ -83,7 +111,7 @@ export async function streamHtml(
       }
     }
 
-    if (shellChunks.length) emit(shellChunks.join(''))
+    if (shellChunks.length) emit(normalizeDocumentShell(shellChunks.join('')))
 
     // 3. Stream suspended boundaries as they resolve
     for (const b of boundaries) streamBoundary(b, emit, options, state)
@@ -144,6 +172,59 @@ async function drain(state: OrchestratorState): Promise<void> {
   while (state.pending.size > 0) {
     await Promise.race(state.pending)
   }
+}
+
+function isThenable(value: unknown): value is Promise<unknown> {
+  return !!value && typeof (value as { then?: unknown }).then === 'function'
+}
+
+function bootstrapScriptContentToArray(
+  content: StreamOptions['bootstrapScriptContent'],
+): string[] {
+  if (content === undefined) return []
+  return typeof content === 'string' ? [content] : [...content]
+}
+
+function inlineBootstrapTag(content: string, defaultNonce: string | undefined): string {
+  const nAttr = defaultNonce ? ` nonce="${defaultNonce}"` : ''
+  return `<script${nAttr}>${escapeScript(content)}</script>`
+}
+
+function normalizeDocumentShell(html: string): string {
+  const doctypeIndex = html.indexOf('<!DOCTYPE html><html')
+  if (doctypeIndex <= 0) return html
+
+  const headPrefix = html.slice(0, doctypeIndex)
+  if (!isHeadPrefix(headPrefix)) return html
+
+  const documentHtml = html.slice(doctypeIndex)
+  const headOpen = documentHtml.match(/<head(?:\s[^>]*)?>/)
+  if (!headOpen || headOpen.index === undefined) return html
+
+  const insertAt = headOpen.index + headOpen[0].length
+  return documentHtml.slice(0, insertAt) + headPrefix + documentHtml.slice(insertAt)
+}
+
+function isHeadPrefix(value: string): boolean {
+  if (!value) return false
+  return stripLeadingHeadTags(value).trim() === ''
+}
+
+function stripLeadingHeadTags(value: string): string {
+  let rest = value
+  let changed = true
+  while (changed) {
+    changed = false
+    const next = rest.replace(
+      /^\s*(?:<meta\b[^>]*>|<link\b[^>]*>|<base\b[^>]*>|<title\b[^>]*>[\s\S]*?<\/title>|<style\b[^>]*>[\s\S]*?<\/style>|<script\b[^>]*>[\s\S]*?<\/script>)/i,
+      '',
+    )
+    if (next !== rest) {
+      rest = next
+      changed = true
+    }
+  }
+  return rest
 }
 
 function bootstrapTag(

--- a/packages/redact/src/server/walk.ts
+++ b/packages/redact/src/server/walk.ts
@@ -315,6 +315,10 @@ function walkHost(
   const parentTextState = opts.textState
   const childOpts: WalkOptions = { ...opts, textState: { lastWasText: false } }
 
+  if (tag === 'html' && !hasHeadChild(props.children)) {
+    opts.emit('<head></head>')
+  }
+
   const dangerouslyHtml = props.dangerouslySetInnerHTML?.__html
 
   if (isTextarea && textareaValue != null) {
@@ -351,6 +355,32 @@ function walkHost(
   if (isSelect) popSelectContext()
   // Host element closing resets outer flow — next sibling text starts fresh.
   if (parentTextState) parentTextState.lastWasText = false
+}
+
+function hasHeadChild(children: unknown): boolean {
+  if (children == null || typeof children === 'boolean') return false
+  if (Array.isArray(children)) return children.some(hasHeadChild)
+  if (typeof children !== 'string' && isIterable(children)) {
+    for (const child of children as Iterable<unknown>) {
+      if (hasHeadChild(child)) return true
+    }
+    return false
+  }
+  return isElementOfType(children, 'head')
+}
+
+function isElementOfType(value: unknown, type: string): value is ReactElement {
+  const marker = (value as ReactElement | null)?.$$typeof as unknown
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (marker === REACT_ELEMENT_TYPE || marker === REACT_LEGACY_ELEMENT_TYPE) &&
+    (value as ReactElement).type === type
+  )
+}
+
+function isIterable(value: unknown): value is Iterable<unknown> {
+  return !!value && typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function'
 }
 
 function walkComponent(

--- a/packages/redact/src/vite/index.ts
+++ b/packages/redact/src/vite/index.ts
@@ -166,6 +166,8 @@ const ALIASES: Record<string, string> = {
   'react/jsx-dev-runtime': '@tanstack/redact/jsx-dev-runtime',
   'react/compiler-runtime': '@tanstack/redact/compiler-runtime',
   'react-dom/client': '@tanstack/redact/dom-client',
+  'react-dom/server.edge': '@tanstack/redact/server',
+  'react-dom/static.edge': '@tanstack/redact/server',
   'react-dom/server': '@tanstack/redact/server',
   'react-dom/test-utils': '@tanstack/redact/dom-test-utils',
   'react-dom': '@tanstack/redact/dom',

--- a/tests/document-hydration.test.tsx
+++ b/tests/document-hydration.test.tsx
@@ -37,6 +37,53 @@ describe('hydrateRoot(document, <html/>)', () => {
     expect(doc.documentElement.querySelector('h1')?.textContent).toBe('hi')
   })
 
+  it('server-renders a head when an html tree omits it', () => {
+    function App() {
+      return (
+        <html>
+          <body>
+            <h1>hi</h1>
+          </body>
+        </html>
+      )
+    }
+
+    expect(renderToString(<App />)).toBe(
+      '<!DOCTYPE html><html><head></head><body><h1>hi</h1></body></html>',
+    )
+  })
+
+  it('hydrates React 19-style top-level head tags from document.head', () => {
+    function App() {
+      return (
+        <>
+          <meta name="viewport" content="width=device-width" />
+          <html>
+            <body>
+              <h1>hi</h1>
+            </body>
+          </html>
+        </>
+      )
+    }
+
+    const doc = buildDocumentFrom(
+      '<!doctype html><html><head><meta name="viewport" content="width=device-width"></head><body><h1>hi</h1></body></html>',
+    )
+    const origHtml = doc.documentElement
+    const errors: unknown[] = []
+
+    hydrateRoot(doc as any, <App />, {
+      onRecoverableError: (e) => errors.push(e),
+      onUncaughtError: (e) => errors.push(e),
+    })
+
+    expect(doc.documentElement).toBe(origHtml)
+    expect(doc.head.querySelectorAll('meta[name="viewport"]').length).toBe(1)
+    expect(doc.documentElement.querySelector('h1')?.textContent).toBe('hi')
+    expect(errors).toEqual([])
+  })
+
   it('a root-level component suspending during hydration does not append a second <html>', async () => {
     // Mirrors Start's <StartClient/> → <Await promise={...}> pattern: the
     // root-most component throws a promise synchronously during hydrateRoot.

--- a/tests/public-exports.test.ts
+++ b/tests/public-exports.test.ts
@@ -109,6 +109,7 @@ describe('public API surface', () => {
   it('@tanstack/redact/dom', () => {
     expect(surface(redactDom)).toMatchInlineSnapshot(`
       [
+        "__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE",
         "createPortal",
         "default",
         "flushSync",

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -146,4 +146,47 @@ describe('renderToReadableStream', () => {
     expect(out).toContain('$RC(')
     await stream.allReady
   })
+
+  it('emits escaped inline bootstrap script content', async () => {
+    const stream = await renderToReadableStream(<div>hello</div>, {
+      bootstrapScriptContent: 'globalThis.started = "</script>"',
+    } as any)
+    const out = await streamToString(stream)
+    expect(out).toContain('<div>hello</div>')
+    expect(out).toContain('<script>globalThis.started = "<\\/script>"</script>')
+    await stream.allReady
+  })
+
+  it('retries when the root render suspends before any boundary', async () => {
+    let resolve!: (value: string) => void
+    const promise = new Promise<string>((r) => {
+      resolve = r
+    })
+    function App() {
+      return <main>{React.use(promise)}</main>
+    }
+
+    const stream = await renderToReadableStream(<App />)
+    resolve('ready')
+    const out = await streamToString(stream)
+    expect(out).toBe('<main>ready</main>')
+    await stream.allReady
+  })
+
+  it('moves leading head tags into an existing document head', async () => {
+    const stream = await renderToReadableStream(
+      <>
+        <meta name="viewport" content="width=device-width" />
+        <html>
+          <head></head>
+          <body>ok</body>
+        </html>
+      </>,
+    )
+    const out = await streamToString(stream)
+    expect(out).toBe(
+      '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width"/></head><body>ok</body></html>',
+    )
+    await stream.allReady
+  })
 })

--- a/tests/vite-plugin.test.ts
+++ b/tests/vite-plugin.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { resolve } from 'node:path'
+import { redact } from '@tanstack/redact/vite'
+
+describe('redact vite plugin', () => {
+  it('aliases React DOM edge server entrypoints', async () => {
+    const packageRoot = resolve(import.meta.dirname, '../packages/redact')
+    const plugin = redact({
+      packageRoots: {
+        '@tanstack/redact': packageRoot,
+      },
+    })
+
+    plugin.configResolved?.({
+      root: resolve(import.meta.dirname, '..'),
+      server: { fs: { allow: [] } },
+    } as any)
+
+    const context = { environment: { name: 'ssr' } }
+    await expect(plugin.resolveId.call(context, 'react-dom/server.edge')).resolves.toMatch(
+      /packages\/redact\/dist\/server\/index\.js$/,
+    )
+    await expect(plugin.resolveId.call(context, 'react-dom/static.edge')).resolves.toMatch(
+      /packages\/redact\/dist\/server\/index\.js$/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Merges six community PRs targeting vinext (Vite RSC App Router) compatibility plus a couple of small cleanups. Individual commits are preserved so git authorship is intact.

- **#8** feat(vite): alias `react-dom/server.edge` and `react-dom/static.edge` → `@tanstack/redact/server` (Steve Faulkner)
- **#11** feat(dom): expose `__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE` no-op stub for Flight `H` rows (Steve Faulkner)
- **#9** feat(server): `bootstrapScriptContent`, root-suspension retry, pre-doctype head-tag normalization in `renderToReadableStream` (Steve Faulkner)
- **#10** feat(dom): project top-level head elements into `document.head` during render/hydration; emit empty `<head>` when missing (Steve Faulkner)
- **#12** chore(hydration): rename internal `__tdom*` scroll-guard globals → `__redact*` (Wonsuk Choi)
- **#13** docs(server): correct fallback wire-format comment — fallback `<div>` is visible, not hidden (Wonsuk Choi)
- chore: bump 0.0.8 → 0.0.9

Closes #8, #9, #10, #11, #12, #13.

## Test plan

- [x] `pnpm test` — 728/728 pass (722 baseline + 6 new)
- [x] `pnpm test:types` — clean
- [x] `pnpm build` — clean
- [x] Tests run after each cherry-pick during integration