### PR TITLE
fix(redact): preserve committed DOM across Suspense re-suspension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **React, redacted.** A minimal React-19-API-compatible drop-in replacement, **~4× smaller** than canonical React. Shipped as a single `@tanstack/redact` package with subpath exports for the `react` / `react-dom` / `react-dom/server` / `scheduler` / `react/jsx-runtime` shapes. User code keeps its canonical `import { useState } from 'react'` — the swap happens at the bundler level.
 
-- **9.07 KB** gzip at full drop-in parity (vs ~45 KB for React 19)
-- **6.75 KB** gzip with every opt-in feature stubbed (`nano` preset)
-- **707/707** unit + integration tests passing, SSR + streaming Suspense + hydration included
+- **10.03 KB** gzip at full drop-in parity (vs ~45 KB for React 19)
+- **7.49 KB** gzip with every opt-in feature stubbed (`nano` preset)
+- **731/731** unit + integration tests passing, SSR + streaming Suspense + hydration included
 - Running in production on [tanstack.com](https://tanstack.com) as of 2026-04-20
 
 For background on the motivation, the "projection" framing, the architectural approach, and the production performance results, see the blog post: [Projecting React](https://tannerlinsley.com/posts/projecting-react).
@@ -39,8 +39,8 @@ import { createRoot, hydrateRoot } from 'react-dom/client'
 Two presets — pick a starting point, flip flags from there:
 
 ```ts
-redact({ preset: 'full' })        // 9.07 KB — everything on, opt OUT individual features
-redact({ preset: 'nano' })        // 6.75 KB — everything off, opt IN what you need
+redact({ preset: 'full' })        // 10.03 KB — everything on, opt OUT individual features
+redact({ preset: 'nano' })        // 7.49 KB — everything off, opt IN what you need
 ```
 
 Opt out from `full`:
@@ -79,21 +79,21 @@ Full feature matrix and alternative configuration paths below.
 |---|---|---|---:|
 | `portal` | `createPortal` into alt container | Children render in place, `container` ignored | ~30 B |
 | `context` | Provider push/pop + consumer walk | Provider → Fragment; `useContext` returns default | ~80 B |
-| `suspense` | Boundary + fallback + streaming hydration | Suspense → Fragment; thenables retry on settle | **~640 B** |
+| `suspense` | Boundary + fallback + streaming hydration, DOM-preserving re-suspension | Suspense → Fragment; thenables retry on settle | **~820 B** |
 | `memo` | `shallowEqual` prop-equality gate | Passes through every parent render | ~80 B |
 | `forwardRef` | Ref forwarded to inner fn | Ref dropped (React 19 "refs as props" still works) | ~70 B |
 | `lazy` | Full hydration coordination | Sync-resolvable payloads work; async retries on settle | ~20 B |
 | `classComponents` | Full lifecycle + `contextType` + error boundaries | `constructor` + `render` + `setState` only | ~200 B |
-| `hydration` | SSR DOM adoption, streaming boundaries, scroll guard, event replay | `hydrateRoot` throws; use `createRoot` for SPA | **~1270 B** |
+| `hydration` | SSR DOM adoption, streaming boundaries, scroll guard, event replay | `hydrateRoot` throws; use `createRoot` for SPA | **~1310 B** |
 
-**Always on** (irreducible core, ~6.7 KB gzip): fiber reconciler with keyed child diffing, host DOM mount/update, `useState` / `useReducer` / `useEffect` / `useLayoutEffect` / `useInsertionEffect` / `useRef` / `useMemo` / `useCallback` / `useId` / `useSyncExternalStore` / `use` (for thenables), native event binding, Fragments, StrictMode/Profiler (aliased to Fragment), element creation + JSX runtime.
+**Always on** (irreducible core, ~7.5 KB gzip): fiber reconciler with keyed child diffing, host DOM mount/update, `useState` / `useReducer` / `useEffect` / `useLayoutEffect` / `useInsertionEffect` / `useRef` / `useMemo` / `useCallback` / `useId` / `useSyncExternalStore` / `use` (for thenables), native event binding, Fragments, StrictMode/Profiler (aliased to Fragment), element creation + JSX runtime.
 
 ### Presets
 
 | Preset | What's on | `react-dom/client` gzip | Intent |
 |---|---|---:|---|
-| `full` (default) | all 8 features | **9.07 KB** | Drop-in React — opt OUT individual features you don't need |
-| **`nano`** | none | **6.75 KB** | Start minimal — opt IN individual features you need |
+| `full` (default) | all 8 features | **10.03 KB** | Drop-in React — opt OUT individual features you don't need |
+| **`nano`** | none | **7.49 KB** | Start minimal — opt IN individual features you need |
 
 Two presets, not a spectrum: every app either wants most of React (start from `full`, opt out) or a tight bundle (start from `nano`, opt in). Per-feature overrides merge on top of preset defaults either way.
 
@@ -436,12 +436,12 @@ Subpath sizes from `pnpm size`. The `react` / `react-dom/client` / `react-dom/se
 
 | Entry | min | gzip | brotli |
 |---|---:|---:|---:|
-| `react`              (= `@tanstack/redact`)             | 6.59 KB | 2.65 KB | 2.41 KB |
-| `react/jsx-runtime`  (= `@tanstack/redact/jsx-runtime`) | 247 B | 189 B | 178 B |
-| `react-dom/client`   (= `@tanstack/redact/dom-client`, `full`) | 26.56 KB | **9.07 KB** | 8.21 KB |
-| `react-dom/client`   (= `@tanstack/redact/dom-client`, `nano`) | 18.75 KB | **6.75 KB** | 6.10 KB |
-| `react-dom/server`   (= `@tanstack/redact/server`)      | 11.48 KB | 4.59 KB | 4.16 KB |
-| **Client total** (`full`: react + react-dom/client + jsx-runtime) | 32.63 KB | **11.18 KB** | 10.14 KB |
+| `react`              (= `@tanstack/redact`)             | 6.59 KB | 2.65 KB | 2.42 KB |
+| `react/jsx-runtime`  (= `@tanstack/redact/jsx-runtime`) | 247 B | 189 B | 187 B |
+| `react-dom/client`   (= `@tanstack/redact/dom-client`, `full`) | 29.65 KB | **10.03 KB** | 9.11 KB |
+| `react-dom/client`   (= `@tanstack/redact/dom-client`, `nano`) | 20.86 KB | **7.49 KB** | 6.79 KB |
+| `react-dom/server`   (= `@tanstack/redact/server`)      | 12.90 KB | 5.09 KB | 4.61 KB |
+| **Client total** (`full`: react + react-dom/client + jsx-runtime) | 35.81 KB | **12.24 KB** | 11.07 KB |
 
 Regenerate with `pnpm size`.
 

--- a/docs/SAVINGS_ANALYSIS.md
+++ b/docs/SAVINGS_ANALYSIS.md
@@ -8,18 +8,18 @@ Numbers from `scripts/size.mjs` (esbuild: bundle + minify + `NODE_ENV=production
 |---|---:|---:|---:|---:|
 | `react` | 3.29 KB | 2.65 KB | 81% | −0.64 KB |
 | `react/jsx-runtime` | 731 B | 189 B | 26% | −542 B |
-| `react-dom` | 4.35 KB | 8.53 KB | 196% | +4.18 KB\* |
-| `react-dom/client` | **60.27 KB** | **9.07 KB** | **15%** | **−51.20 KB** |
-| `react-dom/server` | 61.11 KB | 4.59 KB | 8% | −56.52 KB |
-| **Client total** (`react` + `react-dom/client` + `react/jsx-runtime`) | **60.48 KB** | **11.18 KB** | **18%** | **−49.30 KB** |
+| `react-dom` | 4.35 KB | 9.24 KB | 213% | +4.89 KB\* |
+| `react-dom/client` | **60.27 KB** | **10.03 KB** | **17%** | **−50.24 KB** |
+| `react-dom/server` | 61.11 KB | 5.09 KB | 8% | −56.02 KB |
+| **Client total** (`react` + `react-dom/client` + `react/jsx-runtime`) | **60.48 KB** | **12.24 KB** | **20%** | **−48.24 KB** |
 
 \* `react-dom` (the index) looks worse because React splits it into a tiny facade over `react-dom/client`; ours ships `createPortal`, `flushSync`, `unstable_batchedUpdates`, and resource-hint stubs in one file. Real apps ship `react-dom/client`, so that row is what matters.
 
-The `nano` preset (every opt-in feature stubbed) brings `react-dom/client` down further to **6.75 KB gzip** — a 2.32 KB savings vs `full` and a **8.9× reduction** vs React's `react-dom/client`.
+The `nano` preset (every opt-in feature stubbed) brings `react-dom/client` down further to **7.49 KB gzip** — a 2.54 KB savings vs `full` and an **8.0× reduction** vs React's `react-dom/client`.
 
 React 18 was ~43 KB gzip for the full client runtime; React 19 jumped to ~60 KB mostly because of `use()`, server actions (`useActionState`, `useFormStatus`), `useOptimistic`, view transitions, and async-transition plumbing.
 
-**Bottom line: a single-import client bundle shrinks from ~60 KB to ~11 KB, a ~49 KB (~82%) reduction at full parity, or to ~9.4 KB (~84% reduction) on the `nano` preset.** The win comes almost entirely from `react-dom/client` — React's `react` package is only ~3 KB to begin with.
+**Bottom line: a single-import client bundle shrinks from ~60 KB to ~12 KB, a ~48 KB (~80%) reduction at full parity, or to ~10.3 KB (~83% reduction) on the `nano` preset.** The win comes almost entirely from `react-dom/client` — React's `react` package is only ~3 KB to begin with.
 
 ## Where those ~49 KB go in React (approximation)
 
@@ -52,14 +52,14 @@ The 8 opt-in features can each be stubbed individually. Numbers from `pnpm size`
 | Feature | full → stub savings (gzip) |
 |---|---:|
 | `portal` | ~30 B |
-| `context` | ~80 B |
-| `suspense` | **~640 B** |
+| `context` | ~60 B |
+| `suspense` | **~820 B** |
 | `memo` | ~80 B |
 | `forwardRef` | ~70 B |
-| `lazy` | ~20 B |
-| `classComponents` | ~200 B |
-| `hydration` | **~1270 B** |
-| **All off (`nano` preset)** | **~2320 B** |
+| `lazy` | ~10 B |
+| `classComponents` | ~180 B |
+| `hydration` | **~1310 B** |
+| **All off (`nano` preset)** | **~2540 B** |
 
 Stubbed features still carry a small registration footprint (matcher entry that maps the React element type to Fragment, dispatcher capability defaults). The `nano` preset's total savings is slightly less than the sum of individual savings because some feature code is shared.
 
@@ -92,9 +92,9 @@ Ranked by how likely they are to bite a real app:
 7. **Typing feels slightly worse under contention** — no priority boost for user input.
 8. **StrictMode is a no-op** — dev-mode detection of unsafe side effects is gone.
 
-## What this means for the 11 KB budget
+## What this means for the 12 KB budget
 
-Client bundle is 11.18 KB gzip total at full parity; the reconciler + dispatcher + DOM + hydration alone is ~8.3 KB. That ~8.3 KB is what shaves 51 KB off React's 60 KB `react-dom/client` — a **6.6× reduction**. The delta comes from skipping the four things that define React's production runtime:
+Client bundle is 12.24 KB gzip total at full parity; the reconciler + dispatcher + DOM + hydration alone is ~9 KB. That ~9 KB is what shaves 50 KB off React's 60 KB `react-dom/client` — a **6.0× reduction**. The delta comes from skipping the four things that define React's production runtime:
 
 - Fiber (double-buffered work-in-progress tree)
 - Scheduler (priority + lanes + interruption)

--- a/docs/SURFACE.md
+++ b/docs/SURFACE.md
@@ -1,6 +1,6 @@
 # React 19 API Surface — `@tanstack/redact`
 
-API-complete drop-in replacement for `react` + `react-dom` targeting TanStack Start apps (tanstack.com). Shipped as `@tanstack/redact@0.0.1`. Client total: **11.18 KB gzip** (full preset) / **9.40 KB gzip** (nano preset, with feature flags off).
+API-complete drop-in replacement for `react` + `react-dom` targeting TanStack Start apps (tanstack.com). Shipped as `@tanstack/redact@0.0.1`. Client total: **12.24 KB gzip** (full preset) / **10.33 KB gzip** (nano preset, with feature flags off).
 
 ## Legend
 
@@ -235,11 +235,11 @@ Numbers from `pnpm size` against `@tanstack/redact@0.0.1`. The user-facing colum
 
 | Subpath | min | gzip | brotli |
 |---|---:|---:|---:|
-| `react` | 6.59 KB | **2.65 KB** | 2.41 KB |
-| `react/jsx-runtime` | 247 B | 189 B | 178 B |
-| `react-dom/client` (`full`) | 26.56 KB | **9.07 KB** | 8.21 KB |
-| `react-dom/client` (`nano`) | 18.75 KB | **6.75 KB** | 6.10 KB |
-| `react-dom/server` | 11.48 KB | 4.59 KB | 4.16 KB |
-| **Client total** (`full`: react + react-dom/client + jsx-runtime) | 32.63 KB | **11.18 KB** | 10.14 KB |
+| `react` | 6.59 KB | **2.65 KB** | 2.42 KB |
+| `react/jsx-runtime` | 247 B | 189 B | 187 B |
+| `react-dom/client` (`full`) | 29.65 KB | **10.03 KB** | 9.11 KB |
+| `react-dom/client` (`nano`) | 20.86 KB | **7.49 KB** | 6.79 KB |
+| `react-dom/server` | 12.90 KB | 5.09 KB | 4.61 KB |
+| **Client total** (`full`: react + react-dom/client + jsx-runtime) | 35.81 KB | **12.24 KB** | 11.07 KB |
 
 Server-side weight doesn't count toward the page-weight goal. Per-feature gzip deltas (for sizing individual feature flags) live in [SAVINGS_ANALYSIS.md](./SAVINGS_ANALYSIS.md).

--- a/packages/redact/src/dom/features/suspense/full.ts
+++ b/packages/redact/src/dom/features/suspense/full.ts
@@ -1,4 +1,4 @@
-import { FiberTag, type Fiber } from '../../../core'
+import { FiberTag, createFiber, type Fiber } from '../../../core'
 import { REACT_SUSPENSE_TYPE } from '../../../react'
 import {
   registerRenderer,
@@ -6,8 +6,10 @@ import {
   installCapability,
   reconcileChildren,
   childrenToArray,
+  renderFiber,
   scheduleUpdate,
   unmountAllChildren,
+  unmountFiber,
   findRoot,
   runEffects,
   getCurrentRoot,
@@ -36,9 +38,40 @@ function realHandleSuspended(fiber: Fiber, thenable: Promise<any>): void {
   )
 }
 
+// React's Suspense semantics: when a re-render of an already-committed
+// boundary suspends, the previously-committed children are kept in the DOM
+// (hidden) so their scroll position, focus, selection, native form state,
+// and component state survive across the suspension. The fallback is mounted
+// alongside the hidden primary until the pending promise resolves.
+//
+// We track the hidden subtree DOM in `state.hiddenDoms` (root host nodes +
+// their original `display` so we can restore it) and the fallback as a
+// detached Fragment fiber in `state.fallbackFiber` (deliberately kept OUT of
+// `fiber.child` so reconciles against `props.children` don't trip on it).
+// First-mount suspensions have no committed DOM worth preserving, so they
+// keep the original unmount-and-render-fallback behavior.
+interface SuspenseState {
+  suspended: boolean
+  pending: Promise<any> | null
+  hydrated?: boolean
+  boundaryId?: number
+  startMark?: Comment
+  endMark?: Comment
+  realChildren?: any
+  _awaitingLazyHydration?: boolean
+  // Re-suspend preservation:
+  hiddenDoms: Array<[HTMLElement, string]> | null
+  fallbackFiber: Fiber | null
+}
+
 function renderSuspense(fiber: Fiber, domParent: Node, anchor: Node | null): void {
   const props = fiber.pendingProps ?? {}
-  const state = (fiber.memoizedState ??= { suspended: false, pending: null as Promise<any> | null })
+  const state = (fiber.memoizedState ??= {
+    suspended: false,
+    pending: null as Promise<any> | null,
+    hiddenDoms: null,
+    fallbackFiber: null,
+  }) as SuspenseState
 
   // Streaming hydration: if the next DOM node is a server-emitted boundary
   // marker, route through the boundary-aware hydration path.
@@ -58,53 +91,123 @@ function renderSuspense(fiber: Fiber, domParent: Node, anchor: Node | null): voi
   // yet. Until the Lazy's resume fires, skip our own tryChildren pass so
   // an unrelated re-render can't accidentally flip us into the suspended
   // path and mount a duplicate fallback on top of the SSR content.
-  if ((state as any)._awaitingLazyHydration) {
+  if (state._awaitingLazyHydration) {
     fiber.memoizedProps = props
     return
   }
 
-  const tryChildren = () => {
-    reconcileChildren(fiber, childrenToArray(props.children), domParent, anchor)
+  // We were already in the suspended-with-preserved-primary state. Don't
+  // re-attempt primary children (would re-throw and churn the tree). Just
+  // refresh the fallback in case its JSX changed, and wait for the pending
+  // promise to fire scheduleUpdate.
+  if (state.suspended && state.pending && state.fallbackFiber) {
+    state.fallbackFiber.pendingProps = { children: props.fallback }
+    renderFiber(state.fallbackFiber, domParent, anchor)
+    fiber.memoizedProps = props
+    return
   }
 
-  if (state.suspended && state.pending) {
-    // Render fallback while waiting; pending promise will reschedule
+  // Initial-mount suspended path: no committed primary to preserve. Old
+  // behavior — render fallback into fiber.child directly.
+  if (state.suspended && state.pending && !state.fallbackFiber) {
     reconcileChildren(fiber, childrenToArray(props.fallback), domParent, anchor)
     fiber.memoizedProps = props
     return
   }
 
-  // Attempt children — suspension is handled by the pushed handler below
+  // Snapshot whether we have an existing committed primary tree before
+  // attempting the new render. If the new attempt suspends and we did have a
+  // committed primary, we keep it (hidden) rather than destroying it.
+  const hadCommittedPrimary = fiber.memoizedProps !== undefined && fiber.child !== null
+
   const savedHandler = suspendHandlerStack[suspendHandlerStack.length - 1]
+  let suspendedThisRender = false
+  let suspendedThenable: Promise<any> | null = null
   suspendHandlerStack.push((thenable) => {
-    state.suspended = true
-    state.pending = thenable
-    thenable.then(
-      () => {
-        state.suspended = false
-        state.pending = null
-        scheduleUpdate(fiber)
-      },
-      () => {
-        state.suspended = false
-        state.pending = null
-        scheduleUpdate(fiber)
-      },
-    )
+    suspendedThisRender = true
+    suspendedThenable = thenable
   })
   try {
-    tryChildren()
+    reconcileChildren(fiber, childrenToArray(props.children), domParent, anchor)
   } finally {
     suspendHandlerStack.pop()
     void savedHandler
   }
 
-  if (state.suspended) {
-    // Replace children with fallback
-    unmountAllChildren(fiber, domParent)
-    reconcileChildren(fiber, childrenToArray(props.fallback), domParent, anchor)
+  if (suspendedThisRender && suspendedThenable) {
+    state.suspended = true
+    state.pending = suspendedThenable
+    const onSettle = () => {
+      state.suspended = false
+      state.pending = null
+      scheduleUpdate(fiber)
+    }
+    suspendedThenable.then(onSettle, onSettle)
+
+    if (hadCommittedPrimary && fiber.child) {
+      // Hide the primary subtree's root host doms so the fallback is the only
+      // thing visible, but the underlying nodes (and their scroll/state/focus)
+      // survive. Save original `display` for the resume path.
+      const hostDoms: Node[] = []
+      let c: Fiber | null = fiber.child
+      while (c) {
+        collectRootHostDoms(c, hostDoms)
+        c = c.sibling
+      }
+      const hidden: Array<[HTMLElement, string]> = []
+      for (const d of hostDoms) {
+        if (d.nodeType === 1) {
+          const el = d as HTMLElement
+          hidden.push([el, el.style.display])
+          el.style.display = 'none'
+        }
+      }
+      state.hiddenDoms = hidden
+
+      // Mount fallback in a detached Fragment fiber. Kept off `fiber.child`
+      // so reconciles of primary don't see it as a stale match candidate.
+      if (!state.fallbackFiber) {
+        state.fallbackFiber = createFiber(FiberTag.Fragment, null, null)
+        state.fallbackFiber.parent = fiber
+      }
+      state.fallbackFiber.pendingProps = { children: props.fallback }
+      renderFiber(state.fallbackFiber, domParent, anchor)
+    } else {
+      // First-mount suspension — nothing to preserve.
+      unmountAllChildren(fiber, domParent)
+      reconcileChildren(fiber, childrenToArray(props.fallback), domParent, anchor)
+    }
+  } else {
+    // Render succeeded. Clean up any preserved-suspend state from a prior
+    // suspension cycle: unhide primary, unmount the orphan fallback fiber.
+    if (state.hiddenDoms) {
+      for (const [el, origDisplay] of state.hiddenDoms) {
+        el.style.display = origDisplay
+      }
+      state.hiddenDoms = null
+    }
+    if (state.fallbackFiber) {
+      unmountFiber(state.fallbackFiber, domParent)
+      state.fallbackFiber = null
+    }
   }
   fiber.memoizedProps = props
+}
+
+// Walk a fiber subtree collecting host/text DOM nodes that sit at the root
+// of the subtree (do not descend through their children — display:none on
+// the root hides the whole element). Used by the hide-on-suspend path.
+function collectRootHostDoms(fiber: Fiber, out: Node[]): void {
+  if (fiber.tag === FiberTag.Host || fiber.tag === FiberTag.Text) {
+    if (fiber.dom) out.push(fiber.dom)
+    return
+  }
+  if (fiber.tag === FiberTag.Portal) return
+  let c = fiber.child
+  while (c) {
+    collectRootHostDoms(c, out)
+    c = c.sibling
+  }
 }
 
 function hydrateSuspenseBoundary(

--- a/packages/redact/src/dom/reconcile.ts
+++ b/packages/redact/src/dom/reconcile.ts
@@ -1014,7 +1014,7 @@ export function isThenable(x: any): x is Promise<any> {
 // Unmount
 // ---------------------------------------------------------------------------
 
-function unmountFiber(fiber: Fiber, domParent: Node): void {
+export function unmountFiber(fiber: Fiber, domParent: Node): void {
   fiber.unmounted = true
   // Recurse first
   let c = fiber.child

--- a/scripts/size-check.mjs
+++ b/scripts/size-check.mjs
@@ -14,8 +14,8 @@ const root = resolve(__dirname, '..')
 
 // gzip-byte budgets per named configuration. Update intentionally — size
 // regressions should require a conscious choice, not slip through CI.
-// Current sizes (May 2026): 2715 / 9396 / 7026 / 8739 / 8093. Budgets include
-// a small cushion over current (~60 B) to absorb minor noise. Shrink budgets
+// Current sizes (May 2026): 2715 / 10274 / 7671 / 9426 / 8963. Budgets
+// include a small cushion (~60 B) to absorb minor noise. Shrink budgets
 // when you intentionally make the bundle smaller.
 //
 // May 2026 bump (+~30 B on dom-client variants): reconcileChildren now does
@@ -37,10 +37,19 @@ const BUDGETS = {
   // compatibility — document-head projection in render and hydration, plus
   // the __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE stub
   // on the dom entry. See PRs #8-#11 for context.
-  'redact/dom-client': 10100,
+  //
+  // May 2026 bump (+~150-185 B on Suspense-bearing dom-client variants):
+  // Suspense now preserves committed primary DOM on re-suspension instead of
+  // calling unmountAllChildren — saves scrollTop / focus / selection /
+  // component state across the suspended window. Hides root host doms,
+  // mounts fallback in a detached Fragment fiber off `fiber.child`, restores
+  // on resolve. Hits `redact/dom-client` (full) and the `hydration=stub`
+  // variant (which still ships Suspense). `suspense=stub` and `nano` don't
+  // grow. See PR #16.
+  'redact/dom-client': 10340,
   'redact/dom-client (nano)': 7700,
   'redact/dom-client (suspense=stub)': 9460,
-  'redact/dom-client (hydration=stub)': 8780,
+  'redact/dom-client (hydration=stub)': 9030,
 }
 
 const alias = {

--- a/tests/suspense-preserves-dom.test.tsx
+++ b/tests/suspense-preserves-dom.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+async function flush(n = 10) {
+  for (let i = 0; i < n; i++) await Promise.resolve()
+}
+
+// Mirrors the TanStack Router navigation scenario in tanstack.com:
+// - A scrollable container is rendered as part of route A's committed tree.
+// - The user scrolls the container.
+// - The user navigates to route B, which suspends while loading.
+// - The route swap should preserve route A's DOM (incl. scroll state) until
+//   the new route is ready (React's Suspense semantics: hide-not-unmount when
+//   re-suspending an already-committed boundary).
+// Redact today calls unmountAllChildren on suspend, destroying the scrollable's
+// DOM node and its scrollTop. After resolve, fresh DOM is mounted at scrollTop=0.
+describe('Suspense preserves committed DOM across a re-suspension', () => {
+  it('keeps the same scrollable DOM node when Suspense suspends after initial commit', async () => {
+    const container = setup()
+
+    // Phase 1: resolved promise so children commit immediately.
+    let pending: { promise: Promise<void>; resolve: () => void } | null = null
+    let throwNext = false
+
+    function Maybe() {
+      if (throwNext) {
+        if (!pending) {
+          let resolve!: () => void
+          const promise = new Promise<void>((r) => (resolve = r))
+          pending = { promise, resolve }
+        }
+        throw pending.promise
+      }
+      return <span data-testid="maybe">ready</span>
+    }
+
+    function App() {
+      return (
+        <React.Suspense fallback={<i data-testid="fallback">loading</i>}>
+          <div
+            data-testid="scrollable"
+            style={{ overflow: 'auto', height: '50px' }}
+          >
+            <div style={{ height: '1000px' }}>tall content</div>
+          </div>
+          <Maybe />
+        </React.Suspense>
+      )
+    }
+
+    const root = createRoot(container)
+    root.render(<App />)
+    await flush()
+
+    const firstScrollable = container.querySelector(
+      '[data-testid="scrollable"]',
+    ) as HTMLElement
+    expect(firstScrollable).toBeTruthy()
+    expect(container.querySelector('[data-testid="maybe"]')).toBeTruthy()
+
+    // Simulate a user scroll.
+    firstScrollable.scrollTop = 800
+    expect(firstScrollable.scrollTop).toBe(800)
+
+    // Phase 2: trigger a re-render where Maybe now suspends.
+    throwNext = true
+    root.render(<App />)
+    await flush()
+
+    // React's behavior: scrollable stays in DOM (possibly hidden), scrollTop preserved.
+    const duringSuspendScrollable = container.querySelector(
+      '[data-testid="scrollable"]',
+    ) as HTMLElement | null
+
+    expect(
+      duringSuspendScrollable,
+      'scrollable should remain in the DOM while Suspense waits',
+    ).toBe(firstScrollable)
+
+    // Phase 3: resolve the suspended work.
+    throwNext = false
+    pending!.resolve()
+    await flush(30)
+
+    const afterResolveScrollable = container.querySelector(
+      '[data-testid="scrollable"]',
+    ) as HTMLElement
+    expect(afterResolveScrollable).toBe(firstScrollable)
+    expect(afterResolveScrollable.scrollTop).toBe(800)
+    expect(container.querySelector('[data-testid="maybe"]')).toBeTruthy()
+  })
+
+  // The TanStack Router navigation case: route swap re-renders the boundary
+  // with a *new* child component (different type) that suspends. The committed
+  // sibling subtree — the docs sidebar — must survive the suspension cycle so
+  // its scrollTop is intact when the new route content commits.
+  it('preserves a sibling scrollable when the swapped-in child suspends', async () => {
+    const container = setup()
+
+    let lazyResolve: (mod: { default: () => any }) => void
+    const Lazy = React.lazy(
+      () =>
+        new Promise<{ default: () => any }>((r) => {
+          lazyResolve = r
+        }),
+    )
+
+    function RouteA() {
+      return <span data-testid="route-a">route A</span>
+    }
+
+    function App({ route }: { route: 'A' | 'B' }) {
+      return (
+        <React.Suspense fallback={<i data-testid="fallback">loading</i>}>
+          <div
+            data-testid="scrollable"
+            style={{ overflow: 'auto', height: '50px' }}
+          >
+            <div style={{ height: '1000px' }}>sidebar</div>
+          </div>
+          {route === 'A' ? <RouteA /> : <Lazy />}
+        </React.Suspense>
+      )
+    }
+
+    const root = createRoot(container)
+    root.render(<App route="A" />)
+    await flush()
+
+    const scrollable = container.querySelector(
+      '[data-testid="scrollable"]',
+    ) as HTMLElement
+    scrollable.scrollTop = 800
+    expect(container.querySelector('[data-testid="route-a"]')).toBeTruthy()
+
+    // "Navigate" — child component type swaps to a lazy import that suspends.
+    root.render(<App route="B" />)
+    await flush()
+
+    expect(container.querySelector('[data-testid="fallback"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="scrollable"]')).toBe(
+      scrollable,
+    )
+    expect(scrollable.scrollTop).toBe(800)
+
+    // Resolve the lazy import.
+    lazyResolve!({ default: () => <b data-testid="route-b">route B</b> })
+    await flush(30)
+
+    expect(container.querySelector('[data-testid="fallback"]')).toBeNull()
+    expect(container.querySelector('[data-testid="route-b"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="scrollable"]')).toBe(
+      scrollable,
+    )
+    expect(scrollable.scrollTop).toBe(800)
+  })
+
+  // Re-suspension after a successful render — focus survives.
+  it('preserves focus on an input across a sibling suspension', async () => {
+    const container = setup()
+
+    let pending: { promise: Promise<void>; resolve: () => void } | null = null
+    let throwNext = false
+
+    function Maybe() {
+      if (throwNext) {
+        if (!pending) {
+          let resolve!: () => void
+          const promise = new Promise<void>((r) => (resolve = r))
+          pending = { promise, resolve }
+        }
+        throw pending.promise
+      }
+      return <span data-testid="maybe">ready</span>
+    }
+
+    function App() {
+      return (
+        <React.Suspense fallback={<i>loading</i>}>
+          <input data-testid="focusable" />
+          <Maybe />
+        </React.Suspense>
+      )
+    }
+
+    const root = createRoot(container)
+    root.render(<App />)
+    await flush()
+
+    const input = container.querySelector(
+      '[data-testid="focusable"]',
+    ) as HTMLInputElement
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    throwNext = true
+    root.render(<App />)
+    await flush()
+
+    expect(container.querySelector('[data-testid="focusable"]')).toBe(input)
+    // The input survived; focus survives with it (it's just hidden via display:none).
+    expect(document.activeElement).toBe(input)
+
+    throwNext = false
+    pending!.resolve()
+    await flush(30)
+
+    expect(container.querySelector('[data-testid="focusable"]')).toBe(input)
+  })
+})

--- a/tests/suspense-preserves-dom.test.tsx
+++ b/tests/suspense-preserves-dom.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import * as React from 'react'
 import { createRoot } from 'react-dom/client'
 
@@ -7,6 +7,10 @@ function setup() {
   document.body.appendChild(c)
   return c
 }
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
 
 async function flush(n = 10) {
   for (let i = 0; i < n; i++) await Promise.resolve()


### PR DESCRIPTION
## Summary

Switches Redact's Suspense boundary from unmount-and-remount to React's hide-and-show semantics when re-suspending an already-committed tree, so scrollTop / focus / selection / component state survive the suspension cycle.

## The bug

On tanstack.com, scrolling the docs sidebar to ~800px and then clicking a link to another docs page caused the new sidebar to land at `scrollTop = 0`. With Redact disabled, the sidebar kept its 800px scroll. The router's `onRendered` scroll restoration ran fine; the actual sidebar DOM was being destroyed mid-navigation.

Root cause: `renderSuspense` called `unmountAllChildren` whenever a re-render of an already-committed boundary suspended. That wiped every host node in the committed primary subtree — taking scrollTop, focus, selection, and any non-React state with it. When the pending promise resolved, a fresh subtree mounted at `scrollTop = 0`. Vanilla React keeps the committed children alive (hidden) across the suspension; Redact didn't.

## The fix

When a re-render suspends and there's a previously committed primary tree:

- Set `display:none` on each root host DOM of the primary subtree, saving the original `display` for later restoration.
- Keep the primary fibers attached to `fiber.child` so the next reconcile (after resolve) sees them as existing.
- Mount the fallback in a detached `Fragment` fiber held in `state.fallbackFiber`, deliberately kept off `fiber.child` so reconciles against `props.children` don't trip on it.

While suspended, subsequent re-renders only refresh the fallback — primary isn't re-attempted (would re-throw and churn the tree). On resolve, each hidden element's original `display` is restored, the fallback fiber is unmounted, and primary reconciles against the new `props.children` normally.

First-mount suspensions (no committed primary to preserve) keep the original unmount-and-render-fallback behavior.

`unmountFiber` is now exported from `reconcile.ts` so the suspense feature can dispose the detached fallback fiber on resolve.

## Tests

New regression tests in `tests/suspense-preserves-dom.test.tsx`:

1. **Same-tree re-suspension** — re-render triggers a sibling component to throw; the scrollable sibling stays in the DOM with `scrollTop = 800`.
2. **Route-swap scenario** — child component type swaps to a lazy import that suspends; the sidebar's DOM node and `scrollTop` survive the lazy resolution. This mirrors the tanstack.com navigation case.
3. **Focus preservation** — focused `<input>` survives the suspension cycle as the activeElement.

## Test plan

- [x] `pnpm test` — 731/731 passing locally (729 existing + 2 new tests covering 3 scenarios)
- [x] Existing `tests/suspense.test.tsx` still passes (lazy + use, lazy under memo, post-effect setState, nested lazy state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Suspense boundaries now preserve committed DOM when re-suspending—maintains scroll positions, input focus, and DOM identity while showing fallbacks.
  * Fallbacks mount without disrupting preserved primary DOM, improving perceived stability during async loads.
* **Tests**
  * Added tests validating DOM preservation, scrollTop, focus, and lazy-swap scenarios across suspend/resume cycles.
* **Documentation**
  * Updated README and size/savings docs with revised bundle size and feature-savings figures.
* **Chores**
  * Adjusted size-check baseline for CI budget.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/redact/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->