### PR TITLE
fix(redact): tolerate extension hydration mutations

### DIFF
--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/redact",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "React, redacted. A minimal React-API-compatible drop-in replacement.",
   "type": "module",
   "main": "./dist/react/index.js",

--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -207,6 +207,7 @@ const HEAD_KEY_ATTRS: Record<string, ReadonlyArray<string>> = {
   link: ['rel', 'href', 'sizes', 'type'],
   meta: ['name', 'property', 'charSet', 'httpEquiv'],
   script: ['src', 'type'],
+  style: ['id', 'media', 'nonce', 'title'],
 }
 
 const DOCUMENT_HEAD_TAGS = new Set(['base', 'link', 'meta', 'script', 'style', 'title'])
@@ -355,13 +356,24 @@ export function adoptHostDom(fiber: Fiber, parent: Fiber): boolean {
     tag === 'svg' ||
     ((candidate as Element).namespaceURI === 'http://www.w3.org/2000/svg' &&
       tag !== 'foreignobject')
+  const syncHydrationProps =
+    !props.suppressHydrationWarning &&
+    canRecoverHydrationPropMismatch(candidate, tag)
   validateHydrationProps(fiber, candidate as Element, props, tag, isSvg)
   for (const k in props) {
-    if (k === 'children') continue
-    if (k[0] === 'o' && k[1] === 'n' && typeof props[k] == 'function') {
+    if (
+      k === 'children' ||
+      k === 'key' ||
+      k === 'ref' ||
+      k === 'suppressHydrationWarning' ||
+      k === 'suppressContentEditableWarning'
+    ) continue
+    if (
+      syncHydrationProps ||
+      (k[0] === 'o' && k[1] === 'n' && typeof props[k] == 'function')
+    ) {
       setProp(candidate as Element, k, props[k], undefined, isSvg)
     }
-    // Non-event props: trust the server HTML, skip
   }
   // Set up child cursor for this host's children
   hydrationCursors.set(fiber, new HydrationCursor(candidate))
@@ -372,16 +384,24 @@ export function adoptTextDom(fiber: Fiber, parent: Fiber, text: string): boolean
   const cursor = hydrationCursors.get(findHostParent(parent))
   if (!cursor) return false
   const candidate = cursor.take()
-  if (!candidate) onMismatch(fiber, null)
+  if (!candidate) {
+    onMismatch(fiber, null)
+    return false
+  }
   if (candidate.nodeType === 3) {
     if ((candidate as Text).data !== text) {
-      if (process.env.NODE_ENV !== 'production') {
-        failHydration(
-          fiber,
-          new Error(`Hydration text mismatch: expected "${text}" but found "${(candidate as Text).data}".`),
-        )
+      const recovered = failHydration(
+        fiber,
+        process.env.NODE_ENV !== 'production'
+          ? new Error(
+              `Hydration text mismatch: expected "${text}" but found "${(candidate as Text).data}".`,
+            )
+          : undefined,
+        canRecoverHydrationPropMismatch(candidate),
+      )
+      if (recovered) {
+        ;(candidate as Text).data = text
       }
-      failHydration(fiber)
     }
     fiber.dom = candidate
     return true
@@ -407,26 +427,39 @@ export function findHostParent(fiber: Fiber): Fiber {
   throw new Error()
 }
 
-function onMismatch(fiber: Fiber, actualNode: ChildNode | null): never {
-  if (process.env.NODE_ENV !== 'production') {
-    failHydration(
-      fiber,
-      new Error(
-        `Hydration mismatch: expected <${(fiber.type as string) ?? 'text'}> but found ${
-          actualNode ? (actualNode.nodeType === 1 ? (actualNode as Element).tagName : 'text') : 'nothing'
-        }.`,
-      ),
-    )
-  }
-  failHydration(fiber)
+function onMismatch(fiber: Fiber, actualNode: ChildNode | null): void {
+  failHydration(
+    fiber,
+    process.env.NODE_ENV !== 'production'
+      ? new Error(
+          `Hydration mismatch: expected <${(fiber.type as string) ?? 'text'}> but found ${
+            actualNode ? (actualNode.nodeType === 1 ? (actualNode as Element).tagName : 'text') : 'nothing'
+          }.`,
+        )
+      : undefined,
+  )
 }
 
-function failHydration(fiber: Fiber, error: Error = new Error(PROD_HYDRATION_ERROR)): never {
+function failHydration(
+  fiber: Fiber,
+  error: Error = new Error(PROD_HYDRATION_ERROR),
+  recoverInPlace = false,
+): boolean {
   const root = findRoot(fiber)
   if (root?.re) {
     root.re(error)
   }
+  if (recoverInPlace) return true
   abortHydration(error, findHostRecoveryParent(fiber) ?? fiber)
+}
+
+function canRecoverHydrationPropMismatch(node: Node, tag?: string): boolean {
+  return (
+    tag === 'html' ||
+    tag === 'head' ||
+    tag === 'body' ||
+    !!node.ownerDocument?.head?.contains(node)
+  )
 }
 
 function findHostRecoveryParent(fiber: Fiber): Fiber | null {
@@ -660,6 +693,7 @@ function validateHydrationProps(
 ): void {
   if (props.suppressHydrationWarning) return
 
+  const recoverInPlace = canRecoverHydrationPropMismatch(el, tag)
   let expected: Element | undefined
 
   for (const k in props) {
@@ -681,13 +715,13 @@ function validateHydrationProps(
         html = probe.innerHTML
       }
       if ((el as HTMLElement).innerHTML !== html) {
-        if (process.env.NODE_ENV !== 'production') {
-          failHydration(
-            fiber,
-            new Error(`Hydration HTML mismatch inside <${tag}>.`),
-          )
-        }
-        failHydration(fiber)
+        failHydration(
+          fiber,
+          process.env.NODE_ENV !== 'production'
+            ? new Error(`Hydration HTML mismatch inside <${tag}>.`)
+            : undefined,
+          recoverInPlace,
+        )
       }
       continue
     }
@@ -697,10 +731,13 @@ function validateHydrationProps(
       if (tag === 'input' || tag === 'textarea') {
         if (k === 'value' || props.value == null) {
           if (value != null && (el as HTMLInputElement).value !== '' + value) {
-            if (process.env.NODE_ENV !== 'production') {
-              failHydration(fiber, new Error(`Hydration ${tag} value mismatch on <${tag}>.`))
-            }
-            failHydration(fiber)
+            failHydration(
+              fiber,
+              process.env.NODE_ENV !== 'production'
+                ? new Error(`Hydration ${tag} value mismatch on <${tag}>.`)
+                : undefined,
+              recoverInPlace,
+            )
           }
         }
         continue
@@ -710,10 +747,13 @@ function validateHydrationProps(
     if (tag === 'input' && (k === 'checked' || k === 'defaultChecked')) {
       if (k === 'checked' || props.checked == null) {
         if (value != null && (el as HTMLInputElement).checked !== !!value) {
-          if (process.env.NODE_ENV !== 'production') {
-            failHydration(fiber, new Error(`Hydration checked mismatch on <input>.`))
-          }
-          failHydration(fiber)
+          failHydration(
+            fiber,
+            process.env.NODE_ENV !== 'production'
+              ? new Error(`Hydration checked mismatch on <input>.`)
+              : undefined,
+            recoverInPlace,
+          )
         }
       }
       continue
@@ -721,10 +761,13 @@ function validateHydrationProps(
 
     if (tag === 'option' && k === 'selected') {
       if (value != null && (el as HTMLOptionElement).selected !== !!value) {
-        if (process.env.NODE_ENV !== 'production') {
-          failHydration(fiber, new Error(`Hydration selected mismatch on <option>.`))
-        }
-        failHydration(fiber)
+        failHydration(
+          fiber,
+          process.env.NODE_ENV !== 'production'
+            ? new Error(`Hydration selected mismatch on <option>.`)
+            : undefined,
+          recoverInPlace,
+        )
       }
       continue
     }
@@ -732,14 +775,19 @@ function validateHydrationProps(
     if (k === 'style') {
       expected ??= createHostNode(tag, isSvg)
       setProp(expected, k, value, undefined, isSvg)
-      if ((el as HTMLElement).style.cssText !== (expected as HTMLElement).style.cssText) {
-        if (process.env.NODE_ENV !== 'production') {
-          failHydration(
-            fiber,
-            new Error(`Hydration style mismatch on <${tag}>.`),
-          )
-        }
-        failHydration(fiber)
+      if (
+        !hydrationStylesMatch(
+          (el as HTMLElement).style,
+          (expected as HTMLElement).style,
+        )
+      ) {
+        failHydration(
+          fiber,
+          process.env.NODE_ENV !== 'production'
+            ? new Error(`Hydration style mismatch on <${tag}>.`)
+            : undefined,
+          recoverInPlace,
+        )
       }
       continue
     }
@@ -757,18 +805,34 @@ function validateHydrationProps(
     }
     const actualValue = el.getAttribute(attr)
     if (expectedValue !== actualValue) {
-      if (process.env.NODE_ENV !== 'production') {
-        failHydration(
-          fiber,
-          new Error(
-            `Hydration attribute mismatch on <${tag}> for "${attr}": ` +
-              `expected ${formatHydrationValue(expectedValue)} but found ${formatHydrationValue(actualValue)}.`,
-          ),
-        )
-      }
-      failHydration(fiber)
+      failHydration(
+        fiber,
+        process.env.NODE_ENV !== 'production'
+          ? new Error(
+              `Hydration attribute mismatch on <${tag}> for "${attr}": ` +
+                `expected ${formatHydrationValue(expectedValue)} but found ${formatHydrationValue(actualValue)}.`,
+            )
+          : undefined,
+        recoverInPlace,
+      )
     }
   }
+}
+
+function hydrationStylesMatch(
+  actual: CSSStyleDeclaration,
+  expected: CSSStyleDeclaration,
+): boolean {
+  for (let index = 0; index < expected.length; index++) {
+    const property = expected.item(index)
+    if (
+      actual.getPropertyValue(property) !== expected.getPropertyValue(property) ||
+      actual.getPropertyPriority(property) !== expected.getPropertyPriority(property)
+    ) {
+      return false
+    }
+  }
+  return true
 }
 
 function formatHydrationValue(value: string | null): string {

--- a/scripts/size-check.mjs
+++ b/scripts/size-check.mjs
@@ -14,7 +14,7 @@ const root = resolve(__dirname, '..')
 
 // gzip-byte budgets per named configuration. Update intentionally — size
 // regressions should require a conscious choice, not slip through CI.
-// Current sizes (July 2026): 2570 / 10559 / 7195 / 9686 / 8456. Budgets
+// Current sizes (July 2026): 2572 / 10732 / 7198 / 9862 / 8466. Budgets
 // include a small cushion (~60 B) to absorb minor noise. Shrink budgets
 // when you intentionally make the bundle smaller.
 //
@@ -51,9 +51,12 @@ const BUDGETS = {
   // the first nested mismatch aborts the hydration pass.
   // 0.0.17 hotfix: shared SVG attribute normalization plus document
   // hydration drift handling.
-  'redact/dom-client': 10630,
+  // Dark Reader hydration hardening (+~175 B on hydration-bearing builds):
+  // extension-injected head/inline styles no longer trigger destructive
+  // recovery, and genuine document-shell mismatches are repaired in place.
+  'redact/dom-client': 10800,
   'redact/dom-client (nano)': 7260,
-  'redact/dom-client (suspense=stub)': 9750,
+  'redact/dom-client (suspense=stub)': 9930,
   'redact/dom-client (hydration=stub)': 8520,
 }
 

--- a/tests/document-hydration.test.tsx
+++ b/tests/document-hydration.test.tsx
@@ -324,6 +324,88 @@ describe('hydrateRoot(document, <html/>)', () => {
     expect(htmlEls.length).toBe(1)
   })
 
+  it('ignores extension-injected styles before an identified app style', () => {
+    let doc!: Document
+
+    function App() {
+      const htmlClass = doc.documentElement.className
+      return (
+        <html className={htmlClass}>
+          <head>
+            <style id="critical">{'body{color:red}'}</style>
+          </head>
+          <body>
+            <h1 style={{ color: 'red' }}>app</h1>
+          </body>
+        </html>
+      )
+    }
+
+    doc = buildDocumentFrom(
+      '<!doctype html><html class="dark"><head><style class="darkreader">html{background:black}</style><style id="critical">body{color:red}</style></head><body><h1 style="color:red;--darkreader-inline-color:#ff1a1a" data-darkreader-inline-color="">app</h1></body></html>',
+    )
+    const originalHtml = doc.documentElement
+    const originalHead = doc.head
+    const originalCriticalStyle = doc.querySelector('#critical')
+    const injectedStyle = doc.querySelector('.darkreader')
+    const originalHeading = doc.querySelector<HTMLHeadingElement>('h1')
+    const errors: unknown[] = []
+
+    hydrateRoot(doc as any, <App />, {
+      onRecoverableError: (error) => errors.push(error),
+    })
+
+    expect(errors).toEqual([])
+    expect(doc.documentElement).toBe(originalHtml)
+    expect(doc.head).toBe(originalHead)
+    expect(doc.querySelector('#critical')).toBe(originalCriticalStyle)
+    expect(doc.querySelector('.darkreader')).toBe(injectedStyle)
+    expect(doc.querySelector('h1')).toBe(originalHeading)
+    expect(originalHeading?.style.getPropertyValue('--darkreader-inline-color')).toBe(
+      '#ff1a1a',
+    )
+  })
+
+  it('repairs document shell and head mismatches in place', () => {
+    let doc!: Document
+    const documentClassesSeenDuringRender: string[] = []
+
+    function App() {
+      documentClassesSeenDuringRender.push(doc.documentElement.className)
+      return (
+        <html className="client">
+          <head>
+            <style id="critical">{'body{color:red}'}</style>
+          </head>
+          <body>
+            <h1 id="title">client</h1>
+          </body>
+        </html>
+      )
+    }
+
+    doc = buildDocumentFrom(
+      '<!doctype html><html class="server"><head><style id="critical">body{color:blue}</style></head><body><h1 id="title">client</h1></body></html>',
+    )
+    const originalHtml = doc.documentElement
+    const originalHead = doc.head
+    const errors: unknown[] = []
+
+    expect(() => {
+      hydrateRoot(doc as any, <App />, {
+        onRecoverableError: (error) => errors.push(error),
+      })
+    }).not.toThrow()
+
+    expect(errors).toHaveLength(2)
+    expect(documentClassesSeenDuringRender).toEqual(['server'])
+    expect(doc.documentElement).toBe(originalHtml)
+    expect(doc.documentElement.className).toBe('client')
+    expect(doc.head).toBe(originalHead)
+    expect(doc.querySelector('#title')?.textContent).toBe('client')
+    expect(doc.querySelector('#critical')?.textContent).toBe('body{color:red}')
+  })
+
   it('falls back to body-only client render on document body text mismatch', () => {
     function App() {
       return (


### PR DESCRIPTION
## What changed

- match identified app styles past extension-injected head styles
- tolerate extension-added inline CSS declarations during hydration
- repair document-shell and head mismatches in place
- add Dark Reader and document recovery regression coverage
- release as `@tanstack/redact@0.0.19`

## Why

Dark Reader can mutate the document before hydration. Redact could claim the wrong head style or treat added inline declarations as fatal mismatches, then clear the document during recovery. Components reading `document.documentElement` during that recovery crashed.

## Validation

- `pnpm test` — 772 tests passed
- `pnpm test:types`
- `pnpm size:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hydration recovery for mismatches in document, head, and body elements without unnecessarily replacing existing DOM.
  - Correctly updates recoverable text, form values, styles, attributes, and document classes during hydration.
  - Preserves extension-injected styles while reconciling application-owned head elements.
  - Improved reporting of hydration attribute mismatches.

- **Release**
  - Updated the package version to 0.0.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->