### PR TITLE
fix(redact): preserve muted media and enumerated attribute semantics

### DIFF
--- a/packages/redact/src/core/attributes.ts
+++ b/packages/redact/src/core/attributes.ts
@@ -1,3 +1,9 @@
+export const STRING_BOOLEAN_ATTRS = new Set([
+  'contenteditable',
+  'draggable',
+  'spellcheck',
+])
+
 export function attributeName(name: string, isSvg = false): string {
   if (isSvg && name !== 'viewBox' && SVG_KEBAB_PREFIX.test(name)) {
     return name.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())

--- a/packages/redact/src/dom/dom.ts
+++ b/packages/redact/src/dom/dom.ts
@@ -1,4 +1,4 @@
-import { attributeName } from '../core/attributes'
+import { attributeName, STRING_BOOLEAN_ATTRS } from '../core/attributes'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
@@ -38,9 +38,6 @@ const IDL_ATTRS = new Set([
   'multiple',
   'muted',
   'readonly',
-  'contentEditable',
-  'spellcheck',
-  'draggable',
 ])
 
 export function createHostNode(type: string, isSvg: boolean): Element {
@@ -115,6 +112,12 @@ export function setProp(
   if (name === 'htmlFor') {
     if (next == null) el.removeAttribute('for')
     else el.setAttribute('for', '' + next)
+    return
+  }
+
+  if (STRING_BOOLEAN_ATTRS.has(attr)) {
+    if (next == null) el.removeAttribute(attr)
+    else el.setAttribute(attr, '' + next)
     return
   }
 

--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -6,7 +6,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from '../../../core'
-import { attributeName } from '../../../core/attributes'
+import { attributeName, STRING_BOOLEAN_ATTRS } from '../../../core/attributes'
 import { createHostNode, setProp } from '../../dom'
 import { drainReplayQueue } from '../../event-replay'
 import { discardPendingWork, findRoot, flushSyncWork, renderRoot } from '../../reconcile'
@@ -792,8 +792,9 @@ function validateHydrationProps(
       continue
     }
 
-    const stringifiedBoolean = k.startsWith('aria-') || k.startsWith('data-')
     const attr = attributeName(k, isSvg)
+    const stringifiedBoolean =
+      STRING_BOOLEAN_ATTRS.has(attr) || k.startsWith('aria-') || k.startsWith('data-')
 
     let expectedValue: string | null
     if (value == null || (value === false && !stringifiedBoolean)) {

--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -798,6 +798,9 @@ function validateHydrationProps(
     let expectedValue: string | null
     if (value == null || (value === false && !stringifiedBoolean)) {
       expectedValue = null
+    } else if (k === 'muted' && !isSvg && (tag === 'video' || tag === 'audio')) {
+      // The muted property controls playback; defaultMuted reflects the SSR attribute.
+      expectedValue = value ? '' : null
     } else {
       expected ??= createHostNode(tag, isSvg)
       setProp(expected, k, value, undefined, isSvg)

--- a/packages/redact/src/server/escape.ts
+++ b/packages/redact/src/server/escape.ts
@@ -1,4 +1,4 @@
-import { attributeName } from '../core/attributes'
+import { attributeName, STRING_BOOLEAN_ATTRS } from '../core/attributes'
 
 const ATTR_MAP: Record<string, string> = {
   '&': '&amp;',
@@ -96,11 +96,12 @@ export function attrToHtml(name: string, value: unknown, isSvg = false): string 
 
   const htmlName = attributeName(name, isSvg)
 
-  // aria-* and data-* stringify booleans to `"true"`/`"false"` rather than
-  // using boolean-attribute presence semantics — matches React and the ARIA
-  // spec. Must branch before the general `value === false` / BOOLEAN_ATTRS
-  // path, which would drop them.
-  if (name.startsWith('aria-') || name.startsWith('data-')) {
+  // These attributes need explicit "false", not boolean-attribute absence.
+  if (
+    STRING_BOOLEAN_ATTRS.has(htmlName) ||
+    name.startsWith('aria-') ||
+    name.startsWith('data-')
+  ) {
     return ` ${htmlName}="${escapeAttr(String(value))}"`
   }
 

--- a/tests/hydration.test.tsx
+++ b/tests/hydration.test.tsx
@@ -33,6 +33,80 @@ describe('hydrateRoot', () => {
     expect(container.querySelector('span')).toBe(originalSpan)
   })
 
+  it.each([
+    { tag: 'video', muted: true },
+    { tag: 'video', muted: false },
+    { tag: 'audio', muted: true },
+    { tag: 'audio', muted: false },
+  ])('preserves $tag and source nodes with muted=$muted during hydration', ({ tag, muted }) => {
+    const props = { autoPlay: true, loop: true, muted, playsInline: true }
+    const app = React.createElement(
+      tag,
+      props,
+      <source src="/hero.mp4" type="video/mp4" />,
+    )
+    const container = setupWithHTML(renderToString(app))
+    const media = container.querySelector<HTMLMediaElement>(tag)!
+    const source = container.querySelector('source')!
+    const errors: unknown[] = []
+
+    expect(media.hasAttribute('muted')).toBe(muted)
+    // Playback state may change after parsing without changing the SSR attribute.
+    media.muted = !muted
+
+    const root = hydrateRoot(container, app, {
+      onRecoverableError: (error) => errors.push(error),
+    })
+
+    try {
+      expect(errors).toEqual([])
+      expect(container.querySelector(tag)).toBe(media)
+      expect(container.querySelector('source')).toBe(source)
+      expect(media.defaultMuted).toBe(muted)
+      expect(media.muted).toBe(!muted)
+
+      root.render(React.createElement(
+        tag,
+        { ...props, muted: !muted },
+        <source src="/next.mp4" type="video/mp4" />,
+      ))
+      expect(container.querySelector(tag)).toBe(media)
+      expect(container.querySelector('source')).toBe(source)
+      expect(source.getAttribute('src')).toBe('/next.mp4')
+      expect(media.muted).toBe(!muted)
+
+      root.render(app)
+      expect(media.muted).toBe(muted)
+      expect(media.defaultMuted).toBe(muted)
+    } finally {
+      root.unmount()
+      container.remove()
+    }
+  })
+
+  it.each([
+    { tag: 'video', serverMuted: true },
+    { tag: 'video', serverMuted: false },
+    { tag: 'audio', serverMuted: true },
+    { tag: 'audio', serverMuted: false },
+  ])('reports a genuine $tag muted mismatch from $serverMuted', ({ tag, serverMuted }) => {
+    const container = setupWithHTML(renderToString(
+      React.createElement(tag, { muted: serverMuted }),
+    ))
+    const errors: unknown[] = []
+    const root = hydrateRoot(container, React.createElement(tag, { muted: !serverMuted }), {
+      onRecoverableError: (error) => errors.push(error),
+    })
+
+    try {
+      expect(errors.length).toBeGreaterThan(0)
+      expect(container.querySelector<HTMLMediaElement>(tag)?.muted).toBe(!serverMuted)
+    } finally {
+      root.unmount()
+      container.remove()
+    }
+  })
+
   it('hydrates SVG camelCase attributes using SVG attribute names', () => {
     function App() {
       return (

--- a/tests/hydration.test.tsx
+++ b/tests/hydration.test.tsx
@@ -107,6 +107,66 @@ describe('hydrateRoot', () => {
     }
   })
 
+  describe.each([
+    { prop: 'draggable', attr: 'draggable' },
+    { prop: 'contentEditable', attr: 'contenteditable' },
+    { prop: 'spellCheck', attr: 'spellcheck' },
+  ])('$prop', ({ prop, attr }) => {
+    it.each([true, false])('preserves matching DOM with %s and applies updates', (value) => {
+      const app = React.createElement('div', { [prop]: value })
+      const container = setupWithHTML(renderToString(app))
+      const original = container.querySelector('div')!
+      const errors: unknown[] = []
+      const root = hydrateRoot(container, app, {
+        onRecoverableError: (error) => errors.push(error),
+      })
+
+      try {
+        expect(errors).toEqual([])
+        expect(container.firstChild).toBe(original)
+        for (const { next, expected } of [
+          { next: 'false', expected: 'false' },
+          { next: true, expected: 'true' },
+          { next: false, expected: 'false' },
+          { next: 'true', expected: 'true' },
+          { next: '', expected: '' },
+          { next: null, expected: null },
+          { next: true, expected: 'true' },
+          { next: undefined, expected: null },
+        ]) {
+          root.render(React.createElement('div', { [prop]: next }))
+          expect(container.firstChild).toBe(original)
+          expect(original.getAttribute(attr)).toBe(expected)
+        }
+      } finally {
+        root.unmount()
+        container.remove()
+      }
+    })
+
+    it.each([
+      { serverValue: true, clientValue: false, expected: 'false' },
+      { serverValue: false, clientValue: true, expected: 'true' },
+      { serverValue: null, clientValue: false, expected: 'false' },
+    ])('reports a genuine mismatch from $serverValue to $clientValue', ({ serverValue, clientValue, expected }) => {
+      const container = setupWithHTML(renderToString(
+        React.createElement('div', { [prop]: serverValue }),
+      ))
+      const errors: unknown[] = []
+      const root = hydrateRoot(container, React.createElement('div', { [prop]: clientValue }), {
+        onRecoverableError: (error) => errors.push(error),
+      })
+
+      try {
+        expect(errors.length).toBeGreaterThan(0)
+        expect(container.querySelector('div')?.getAttribute(attr)).toBe(expected)
+      } finally {
+        root.unmount()
+        container.remove()
+      }
+    })
+  })
+
   it('hydrates SVG camelCase attributes using SVG attribute names', () => {
     function App() {
       return (

--- a/tests/react-integration/attributes.test.tsx
+++ b/tests/react-integration/attributes.test.tsx
@@ -18,6 +18,47 @@ import * as React from 'react'
 import { itRenders } from './harness'
 
 describe('ReactDOMServerIntegration / attributes', () => {
+  itRenders('explicit false enumerated attributes', async (render) => {
+    const element = await render(
+      <div draggable={false} contentEditable={false} spellCheck={false} />,
+    )
+    expect(element).toHaveProperty(
+      'outerHTML',
+      '<div draggable="false" contenteditable="false" spellcheck="false"></div>',
+    )
+  })
+
+  describe.each([
+    { prop: 'draggable', attr: 'draggable' },
+    { prop: 'contentEditable', attr: 'contenteditable' },
+    { prop: 'spellCheck', attr: 'spellcheck' },
+  ])('$prop', ({ prop, attr }) => {
+    for (const { value, expected } of [
+      { value: true, expected: 'true' },
+      { value: false, expected: 'false' },
+      { value: 'true', expected: 'true' },
+      { value: 'false', expected: 'false' },
+      { value: '', expected: '' },
+      { value: null, expected: null },
+      { value: undefined, expected: null },
+    ]) {
+      itRenders(`${prop}=${JSON.stringify(value)}`, async (render) => {
+        const element = await render(React.createElement('div', { [prop]: value }))
+        expect(element).toHaveProperty(
+          'outerHTML',
+          expected === null ? '<div></div>' : `<div ${attr}="${expected}"></div>`,
+        )
+      })
+    }
+  })
+
+  for (const value of ['plaintext-only', 'inherit', 'TRUE']) {
+    itRenders(`contentEditable="${value}" without normalization`, async (render) => {
+      const element = await render(<div contentEditable={value} />)
+      expect(element).toHaveProperty('outerHTML', `<div contenteditable="${value}"></div>`)
+    })
+  }
+
   describe('string properties', () => {
     itRenders('simple numbers', async (render) => {
       const e = (await render(<div width={30} />)) as HTMLElement


### PR DESCRIPTION
Server-rendered muted media and enumerated attributes can disagree with Redact's hydration validator. Matching `<video muted>`, `<audio muted>`, `draggable={true}`, and `contentEditable={true}` can cause unnecessary DOM replacement. `draggable="false"` can become draggable, while boolean false for `contentEditable` and `spellCheck` is omitted instead of explicitly disabling the behavior.

This change:

- Validates the serialized `muted` attribute on audio/video while preserving live playback state and subsequent property updates.
- Shares the `contentEditable`, `draggable`, and `spellCheck` classification across SSR, DOM setters, and hydration. These attributes preserve explicit `"true"`/`"false"` strings, supported string values, and removal through null/undefined.
- Retains genuine mismatch reporting and recovery.

The attribute handling follows [React 19.2.3's DOM setter](https://github.com/react/react/blob/v19.2.3/packages/react-dom-bindings/src/client/ReactDOMComponent.js) and the HTML definitions for [draggable](https://html.spec.whatwg.org/multipage/dnd.html#the-draggable-attribute), [contenteditable](https://html.spec.whatwg.org/multipage/interaction.html#attr-contenteditable), and [spellcheck](https://html.spec.whatwg.org/multipage/interaction.html#attr-spellcheck). For media, [defaultMuted reflects the HTML attribute](https://html.spec.whatwg.org/multipage/media.html#dom-media-defaultmuted), whereas `muted` controls live playback.

Validation:

- Reproduced the media hydration mismatch before its fix. The new explicit-false regression also failed before the enumerated-attribute fix in all four existing integration strategies: SSR string, SSR stream, client mount, and hydration.
- Regression coverage includes audio/video and source identity, live muted state changes before hydration, enum boolean/string/empty/null/undefined values, contentEditable modes, subsequent updates and removal, and genuine mismatches.
- `pnpm test`: 895 tests passed across 42 files.
- `pnpm test:types`, `pnpm build`, and `git diff --check`: passed.
- Production-bundled Chrome comparison: all 17 initial cases and 73 enum update observations exactly match React 19.2.3, including markup, live properties and DOM identity. Baseline Redact reproduced five unnecessary remounts; the expanded patch produced none and reported no recoverable errors for matching markup.

Safari and Firefox are not verified. The fixtures establish rendering/hydration correctness; they do not measure production bandwidth or Core Web Vitals improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration handling for the `muted` attribute on video and audio elements.
  * Preserved existing media and source elements during hydration.
  * Ensured subsequent muted state updates correctly apply to media elements.
  * Hydration mismatches now report recoverable errors while applying the client-side state.
  * Corrected handling of `draggable`, `contentEditable`, and `spellCheck` values so their string representations are preserved during server rendering, client updates, and hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->